### PR TITLE
Fix typos in name generation

### DIFF
--- a/src/world/npc/ethnicity/celtic.rs
+++ b/src/world/npc/ethnicity/celtic.rs
@@ -10,7 +10,7 @@ impl Ethnicity {
     const FEMININE_NAMES: &'static [&'static str] = &[
         "Aife", "Aina", "Alane", "Ardena", "Arienh", "Beatha", "Birgit", "Briann", "Caomh", "Cara",
         "Cinnia", "Cordelia", "Deheune", "Divone", "Donia", "Doreena", "Elsha", "Enid", "Ethne",
-        "Evelina", "Fianna", "Genevieve", "Gilda", "Gitta", "Grania", "Gwyndolin", "ldelisa",
+        "Evelina", "Fianna", "Genevieve", "Gilda", "Gitta", "Grania", "Gwyndolin", "Idelisa",
         "Isolde", "Keelin", "Kennocha", "Lavena", "Lesley", "Linnette", "Lyonesse", "Mabina",
         "Marvina", "Mavis", "Mirna", "Morgan", "Muriel", "Nareena", "Oriana", "Regan", "Ronat",
         "Rowena", "Selma", "Ula", "Venetia", "Wynne", "Yseult",
@@ -21,7 +21,7 @@ impl Ethnicity {
         "Airell", "Airic", "Alan", "Anghus", "Aodh", "Bardon", "Bearacb", "Bevyn", "Boden", "Bran",
         "Brasil", "Bredon", "Brian", "Bricriu", "Bryant", "Cadman", "Caradoc", "Cedric", "Conalt",
         "Conchobar", "Condon", "Darcy", "Devin", "Dillion", "Donaghy", "Donall", "Duer", "Eghan",
-        "Ewyn", "Ferghus", "Galvyn", "Gildas", "Guy", "Harvey", "Iden", "lrven", "Karney", "Kayne",
+        "Ewyn", "Ferghus", "Galvyn", "Gildas", "Guy", "Harvey", "Iden", "Irven", "Karney", "Kayne",
         "Kelvyn", "Kunsgnos", "Leigh", "Maccus", "Moryn", "Neale", "Owyn", "Pryderi", "Reaghan",
         "Taliesin", "Tiernay", "Turi",
     ];

--- a/src/world/npc/ethnicity/dragonborn.rs
+++ b/src/world/npc/ethnicity/dragonborn.rs
@@ -20,7 +20,7 @@ impl Ethnicity {
     const MASCULINE_NAMES: &'static [&'static str] = &[
         "Adrex", "Arjhan", "Azzakh", "Salasar", "Baradad", "Bharash", "Bidreked", "Dadalan",
         "Dazzazn", "Direcris", "Donaar", "Fax", "Gargax", "Ghesh", "Gorbundus", "Greethen",
-        "Heskan", "Hirrathak", "lldrex", "Kaladan", "Kerkad", "Kiirith", "Kriv", "Maagog",
+        "Heskan", "Hirrathak", "Ildrex", "Kaladan", "Kerkad", "Kiirith", "Kriv", "Maagog",
         "Medrash", "Mehen", "Mozikth", "Mreksh", "Mugrunden", "Nadarr", "Nithther", "Norkruuth",
         "Nykkan", "Pandjed", "Patrin", "Pijjirik", "Quarethon", "Rathkran", "Rhogar", "Rivaan",
         "Sethrekar", "Shamash", "Shedinn", "Srorthen", "Tarhun", "Torinn", "Trynnicus", "Valorean",
@@ -30,15 +30,15 @@ impl Ethnicity {
     #[rustfmt::skip]
     const CLAN_NAMES: &'static [&'static str] = &[
         "Akambherylliax", "Argenthrixus", "Baharoosh", "Beryntolthropal", "Bhenkumbyrznaax",
-        "Caavylteradyn", "Chumbyxirinnish", "Clethtinthial", "lor", "Daardendrian", "Delmirev",
+        "Caavylteradyn", "Chumbyxirinnish", "Clethtinthiallor", "Daardendrian", "Delmirev",
         "Dhyrktelonis", "Ebynichtomonis", "Esstyrlynn", "Fharngnarthnost", "Ghaallixirn",
-        "Grrrmmballhyst", "Gygazzylyshrift", "Hashphronyxadyn", "Hshhsstoroth", "lmbixtellrhyst",
+        "Grrrmmballhyst", "Gygazzylyshrift", "Hashphronyxadyn", "Hshhsstoroth", "Imbixtellrhyst",
         "Jerynomonis", "Jharthraxyn", "Kerrhylon", "Kimbatuul", "Lhamboldennish",
         "Linxakasendalor", "Mohradyllion", "Mys", "tan", "Nemmonis", "Norixius", "Ophinshtalajiir",
         "Orexijandilin", "Pfaphnyrennish", "Phrahdrandon", "Pyraxtallinost", "Qyxpahrgh",
         "Raghthroknaar", "Shestendeliath", "Skaarzborroosh", "Sumnarghthrysh", "Tiammanthyllish",
         "Turnuroth", "Umbyrphrael", "Vangdondalor", "Verthisathurgiesh", "Wivvyrholdalphiax",
-        "Wystongjiir", "Xephyrbahnor", "Yarjerit", "Zzzxaaxthroth", 
+        "Wystongjiir", "Xephyrbahnor", "Yarjerit", "Zzzxaaxthroth",
     ];
 }
 
@@ -85,10 +85,10 @@ mod test_generate_for_ethnicity {
             [
                 "Akambherylliax Srorthen",
                 "Raghthroknaar Nithther",
-                "Hashphronyxadyn Biri",
-                "Turnuroth Megren",
-                "Daardendrian Azzakh",
-                "Pfaphnyrennish Kava"
+                "Lhamboldennish Gilkass",
+                "Ebynichtomonis Biri",
+                "Kerrhylon Furrele",
+                "Wivvyrholdalphiax Rivaan"
             ],
             [
                 gen_name(&mut rng, &age, &m),

--- a/src/world/npc/ethnicity/egyptian.rs
+++ b/src/world/npc/ethnicity/egyptian.rs
@@ -9,7 +9,7 @@ impl Ethnicity {
     #[rustfmt::skip]
     const FEMININE_NAMES: &'static [&'static str] = &[
         "A\'at", "Ahset", "Amunet", "Aneksi", "Atet", "Baketamon", "Betrest", "Bunefer", "Dedyet",
-        "Hatshepsut", "Hentie", "Herit", "Hetepheres", "lntakaes", "lpwet", "ltet", "Joba",
+        "Hatshepsut", "Hentie", "Herit", "Hetepheres", "Intakaes", "Ipwet", "Itet", "Joba",
         "Kasmut", "Kemanub", "Khemut", "Kiya", "Maia", "Menhet", "Merit", "Meritamen", "Merneith",
         "Merseger", "Muyet", "Nebet", "Nebetah", "Nedjemmut", "Nefertiti", "Neferu", "Neithotep",
         "Nit", "Nofret", "Nubemiunu", "Peseshet", "Pypuy", "Qalhata", "Rai", "Redji", "Sadeh",
@@ -19,8 +19,8 @@ impl Ethnicity {
     #[rustfmt::skip]
     const MASCULINE_NAMES: &'static [&'static str] = &[
         "Ahmose", "Akhom", "Amasis", "Amenemhet", "Anen", "Banefre", "Bek", "Djedefre", "Djoser",
-        "Hekaib", "Henenu", "Horemheb", "Horwedja", "Huya", "lbebi", "ldu", "lmhotep", "lneni",
-        "lpuki", "lrsu", "Kagemni", "Kawab", "Kenamon", "Kewap", "Khaemwaset", "Khafra",
+        "Hekaib", "Henenu", "Horemheb", "Horwedja", "Huya", "Ibebi", "Idu", "Imhotep", "Ineni",
+        "Ipuki", "Irsu", "Kagemni", "Kawab", "Kenamon", "Kewap", "Khaemwaset", "Khafra",
         "Khusebek", "Masaharta", "Meketre", "Menkhaf", "Merenre", "Metjen", "Nebamun", "Nebetka",
         "Nehi", "Nekure", "Nessumontu", "Pakhom", "Pawah", "Pawero", "Ramose", "Rudjek", "Sabaf",
         "Sebek-khu", "Sebni", "Senusret", "Shabaka", "Somintu", "Thaneni", "Thethi",

--- a/src/world/npc/ethnicity/gnomish.rs
+++ b/src/world/npc/ethnicity/gnomish.rs
@@ -24,19 +24,19 @@ impl Ethnicity {
         "Fabien", "Fibblestib", "Fonkin", "Frouse", "Frug", "Gerbo", "Gimble", "Glim", "Igden",
         "Jabbie", "jebeddo", "Kellen", "Kipper", "Namfoodle", "Oppleby", "Orryn", "Paggen",
         "Pallabar", "Pog", "Qualen", "Ribbles", "Rimple", "Roondar", "Sapply", "Seebo", "Senteq",
-        "Sindri", "Umpen", "Warryn", "Wiggens", "Wobbles", "Wrenn", "Zaffrab", "Zook", 
+        "Sindri", "Umpen", "Warryn", "Wiggens", "Wobbles", "Wrenn", "Zaffrab", "Zook",
     ];
 
     #[rustfmt::skip]
     const FAMILY_NAMES: &'static [&'static str] = &[
         "Albaratie", "Bafflestone", "Beren", "Boondiggles", "Cobblelob", "Daergel", "Dunben",
-        "Fabblestabble", "Fapplestamp", "Fiddlefen", "Folkor", "Garrick", "Gim", "len",
-        "Glittergem", "Gobblefirn", "Gummen", "Horcusporcus", "Humplebumple", "Ironhide",
-        "Leffery", "Lingenhall", "Loofollue", "Maekkelferce", "Miggledy", "Munggen", "Murnig",
-        "Musgraben", "Nackle", "Ningel", "Nopenstallen", "Nucklestamp", "Offund", "Oomtrowl",
-        "Pilwicken", "Pingun", "Quillsharpener", "Rau", "lnor", "Reese", "Rofferton", "Scheppen",
-        "Shadowcloak", "Silverthread", "Sympony", "Tarkelby", "Timbers", "Turen", "Umbodoben",
-        "Waggletop", "Welber", "Wildwander",
+        "Fabblestabble", "Fapplestamp", "Fiddlefen", "Folkor", "Garrick", "Gimlen", "Glittergem",
+        "Gobblefirn", "Gummen", "Horcusporcus", "Humplebumple", "Ironhide", "Leffery",
+        "Lingenhall", "Loofollue", "Maekkelferce", "Miggledy", "Munggen", "Murnig", "Musgraben",
+        "Nackle", "Ningel", "Nopenstallen", "Nucklestamp", "Offund", "Oomtrowl", "Pilwicken",
+        "Pingun", "Quillsharpener", "Raulnor", "Reese", "Rofferton", "Scheppen", "Shadowcloak",
+        "Silverthread", "Sympony", "Tarkelby", "Timbers", "Turen", "Umbodoben", "Waggletop",
+        "Welber", "Wildwander",
     ];
 }
 
@@ -86,9 +86,9 @@ mod test_generate_for_ethnicity {
                 "Alston Tarkelby",
                 "Oppleby Humplebumple",
                 "Callybon Silverthread",
-                "Orla Loofollue",
-                "Anverth Turen",
-                "Oda Leffery"
+                "Orla Gummen",
+                "Anverth Scheppen",
+                "Oda Glittergem"
             ],
             [
                 gen_name(&mut rng, &age, &m),

--- a/src/world/npc/ethnicity/greek.rs
+++ b/src/world/npc/ethnicity/greek.rs
@@ -21,8 +21,8 @@ impl Ethnicity {
     const MASCULINE_NAMES: &'static [&'static str] = &[
         "Adonis", "Adrastos", "Aeson", "Aias", "Aineias", "Aiolos", "Alekto", "Name", "Alkeides",
         "Argos", "Brontes", "Damazo", "Dardanos", "Deimos", "Diomedes", "Endymion", "Epimetheus",
-        "Erebos", "Euandros", "Ganymedes", "Glaukos", "Hektor", "Heros", "Hippolytos", "lacchus",
-        "lason", "Kadmos", "Kastor", "Kephalos", "Kepheus", "Koios", "Kreios", "Laios", "Leandros",
+        "Erebos", "Euandros", "Ganymedes", "Glaukos", "Hektor", "Heros", "Hippolytos", "Iacchus",
+        "Iason", "Kadmos", "Kastor", "Kephalos", "Kepheus", "Koios", "Kreios", "Laios", "Leandros",
         "Linos", "Lykos", "Melanthios", "Menelaus", "Mentor", "Neoptolemus", "Okeanos", "Orestes",
         "Pallas", "Patroklos", "Philandros", "Phoibos", "Phrixus", "Priamos", "Pyrrhos", "Xanthos",
         "Zephyros",

--- a/src/world/npc/ethnicity/norse.rs
+++ b/src/world/npc/ethnicity/norse.rs
@@ -21,9 +21,9 @@ impl Ethnicity {
         "Agni", "Alaric", "Anvindr", "Arvid", "Asger", "Asmund", "Bjarte", "Bjorg", "Bjorn",
         "Brandr", "Brandt", "Brynjar", "Calder", "Colborn", "Cuyler", "Egil", "Einar", "Eric",
         "Erland", "Fiske", "Folkvar", "Fritjof", "Frede", "Geir", "Halvar", "Hemming", "Hjalmar",
-        "Hjortr", "lngimarr", "Ivar", "Knud", "Leif", "Liufr", "Manning", "Oddr", "Olin", "Ormr",
+        "Hjortr", "Ingimarr", "Ivar", "Knud", "Leif", "Liufr", "Manning", "Oddr", "Olin", "Ormr",
         "Ove", "Rannulfr", "Sigurd", "Skari", "Snorri", "Sten", "Stigandr", "Stigr", "Sven",
-        "Trygve", "Ulf", "Vali", "Vidar", 
+        "Trygve", "Ulf", "Vali", "Vidar",
     ];
 }
 

--- a/src/world/npc/ethnicity/tiefling.rs
+++ b/src/world/npc/ethnicity/tiefling.rs
@@ -9,7 +9,7 @@ impl Ethnicity {
     #[rustfmt::skip]
     const FEMININE_NAMES: &'static [&'static str] = &[
         "Akta", "Anakis", "Armara", "Astaro", "Aym", "Azza", "Beleth", "Bryseis", "Bune",
-        "Criella", "Damaia", "Decarabia", "Ea", "Gadreel", "Gomory", "Hecat", "lshte", "Jezebeth",
+        "Criella", "Damaia", "Decarabia", "Ea", "Gadreel", "Gomory", "Hecat", "Ishte", "Jezebeth",
         "Kali", "Kallista", "Kasdeya", "Lerissa", "Lilith", "Makaria", "Manea", "Markosian",
         "Mastema", "Naamah", "Nemeia", "Nija", "Orianna", "Osah", "Phelaia", "Prosperine", "Purah",
         "Pyra", "Rieta", "Ronobe", "Ronwe", "Seddit", "Seere", "Sekhmet", "Semyaza", "Shava",
@@ -20,7 +20,7 @@ impl Ethnicity {
     const MASCULINE_NAMES: &'static [&'static str] = &[
         "Abad", "Ahrim", "Akmen", "Amnon", "Andram", "Astar", "Balam", "Barakas", "Bathin",
         "Cairn", "Chem", "Cimer", "Cressel", "Damakos", "Ekemon", "Euron", "Fenriz", "Forcas",
-        "Habor", "lados", "Kairon", "Leucis", "Mamnen", "Mantus", "Marbas", "Melech", "Merihim",
+        "Habor", "Iados", "Kairon", "Leucis", "Mamnen", "Mantus", "Marbas", "Melech", "Merihim",
         "Modean", "Mordai", "Mormo", "Morthos", "Nicor", "Nirgel", "Oriax", "Paymon", "Pelaios",
         "Purson", "Qemuel", "Raam", "Rimmon", "Sammal", "Skamos", "Tethren", "Thamuz", "Therai",
         "Valafar", "Vassago", "Xappan", "Zepar", "Zephan",


### PR DESCRIPTION
Fix some OCR-related typos, specifically confusing capital I for lower-case l and introducing spaces where there shouldn't be any. One day the name generation will be done using my own content, but that day is not today.