### PR TITLE
Fix generated NPC subtypes

### DIFF
--- a/core/src/world/npc/mod.rs
+++ b/core/src/world/npc/mod.rs
@@ -60,7 +60,7 @@ pub fn command(command: &RawCommand, demographics: &Demographics) -> Box<dyn fmt
             output.push_str(&format!(
                 "{} {}\n",
                 i,
-                Npc::generate(&mut thread_rng(), demographics).display_summary()
+                Npc::generate(&mut thread_rng(), &session_demographics).display_summary()
             ))
         });
 


### PR DESCRIPTION
When inputting a species (eg. "gnome"), all results should be of that species. Fixed a bug where instead the subsequent suggestions were a mix according to available demographics.

Resolves #24.