### PR TITLE
Add integration test coverage for core

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Run Clippy
         run: cargo clippy -- --deny warnings
       - name: Run unit tests
-        run: cargo test --lib --workspace --verbose
+        run: cargo test --workspace --verbose

--- a/core/tests/app.rs
+++ b/core/tests/app.rs
@@ -1,0 +1,27 @@
+use initiative_core::app;
+
+#[test]
+fn debug() {
+    let mut app = app();
+
+    let empty_output = format!("{}", app.command("debug"));
+    assert!(empty_output.starts_with("Context { "), "{}", empty_output);
+
+    app.command("npc");
+
+    let populated_output = format!("{}", app.command("debug"));
+    assert!(
+        populated_output.len() > empty_output.len(),
+        "Empty:\n{}\n\nPopulated:\n{}",
+        empty_output,
+        populated_output,
+    );
+}
+
+#[test]
+fn unknown() {
+    assert_eq!(
+        "RawCommand { text: \"blah blah\", words: [Unknown(\"blah\"), Unknown(\"blah\")] }",
+        format!("{}", app().command("blah blah")).as_str()
+    );
+}

--- a/core/tests/world_location.rs
+++ b/core/tests/world_location.rs
@@ -1,0 +1,86 @@
+use initiative_core::app;
+
+#[test]
+fn results_are_random() {
+    assert_ne!(
+        format!("{}", app().command("building")),
+        format!("{}", app().command("building")),
+    );
+}
+
+#[test]
+fn generated_content_is_limited_by_building_type() {
+    ["inn", "residence", "shop", "temple", "warehouse"]
+        .iter()
+        .for_each(|building_type| {
+            let output = format!("{}", app().command(building_type));
+            let building_type_capitalized: String = building_type
+                .char_indices()
+                .map(|(i, c)| if i == 0 { c.to_ascii_uppercase() } else { c })
+                .collect();
+
+            assert!(
+                output.matches(building_type_capitalized.as_str()).count() >= 11,
+                "Input: {}\n\nOutput:\n{}",
+                building_type,
+                output,
+            );
+        });
+}
+
+#[test]
+fn generated_content_is_persisted() {
+    let mut app = app();
+    let generated_output = format!("{}", app.command("inn"));
+
+    // The Roaring Spirit
+    // Type: Inn
+    // Gathering place for a secret society
+    //
+    // Alternatives:
+    // 0 The Lonely Rose, an Inn
+    // 1 The Roaring Star, an Inn
+    // 2 The Howling Spirit, an Inn
+    // 3 The Lonely Dolphin, an Inn
+    // 4 The Prancing Lamb, an Inn
+    // 5 The Leering Star, an Inn
+    // 6 The Staggering Pegasus, an Inn
+    // 7 The Prancing Horde, an Inn
+    // 8 The Black Star, an Inn
+    // 9 The Prancing Pegasus, an Inn
+
+    // Ensure that the primary suggestion matches the generated content.
+    let name = generated_output.lines().next().unwrap();
+    let persisted_output = format!("{}", app.command(name));
+    assert_eq!(Some(name), persisted_output.lines().next());
+    assert_eq!(
+        3,
+        generated_output
+            .lines()
+            .zip(persisted_output.lines())
+            .map(|(generated, persisted)| assert_eq!(generated, persisted))
+            .count(),
+        "Generated:\n{}\n\nPersisted:\n{}",
+        generated_output,
+        persisted_output,
+    );
+
+    // Ensure that secondary suggestions have also been persisted.
+    assert_eq!(
+        10,
+        generated_output
+            .lines()
+            .filter(|line| line.starts_with(char::is_numeric))
+            .map(|s| {
+                if let Some(pos) = s.find(',') {
+                    let name = &s[2..pos];
+                    assert_eq!(Some(name), format!("{}", app.command(name)).lines().next());
+                } else {
+                    panic!("Missing , in \"{}\"", s);
+                }
+            })
+            .count(),
+        "{}",
+        generated_output,
+    );
+}

--- a/core/tests/world_npc.rs
+++ b/core/tests/world_npc.rs
@@ -1,0 +1,96 @@
+use initiative_core::app;
+
+#[test]
+fn results_are_random() {
+    assert_ne!(
+        format!("{}", app().command("npc")),
+        format!("{}", app().command("npc")),
+    );
+}
+
+#[test]
+fn generated_content_is_limited_by_species() {
+    [
+        "dragonborn",
+        "dwarf",
+        "elf",
+        "gnome",
+        "halfling",
+        "half-elf",
+        "half-orc",
+        "human",
+        "tiefling",
+        "warforged",
+    ]
+    .iter()
+    .for_each(|species| {
+        let output = format!("{}", app().command(species));
+        assert_eq!(11, output.matches(species).count(), "{}", output);
+    });
+
+    [("half elf", "half-elf"), ("half orc", "half-orc")]
+        .iter()
+        .for_each(|(input, species)| {
+            let output = format!("{}", app().command(input));
+            assert_eq!(11, output.matches(species).count(), "{}", output);
+        });
+}
+
+#[test]
+fn generated_content_is_persisted() {
+    let mut app = app();
+    let generated_output = format!("{}", app.command("npc"));
+
+    // Naal Tiltathana
+    // Species: half-elf (Half-Elvish)
+    // Gender: masculine (he/him)
+    // Age: young adult (24 years)
+    // Size: 5'10", 132 lbs (medium)
+    //
+    // Alternatives:
+    // 0 Amadi (elderly human, he/him)
+    // 1 Daiki (adult half-elf, he/him)
+    // 2 Rostislav (young adult human, he/him)
+    // 3 Gang (middle-aged human, he/him)
+    // 4 Laucian Caerdonel (middle-aged elf, he/him)
+    // 5 Philandros (middle-aged human, he/him)
+    // 6 Makai (adult half-elf, he/him)
+    // 7 Bapoto (elderly human, he/him)
+    // 8 Gebhuza (elderly half-elf, he/him)
+    // 9 Marguerite (middle-aged human, she/her)
+
+    // Ensure that the primary suggestion matches the generated content.
+    let name = generated_output.lines().next().unwrap();
+    let persisted_output = format!("{}", app.command(name));
+    assert_eq!(Some(name), persisted_output.lines().next());
+    assert_eq!(
+        5,
+        generated_output
+            .lines()
+            .zip(persisted_output.lines())
+            .map(|(generated, persisted)| assert_eq!(generated, persisted))
+            .count(),
+        "Generated:\n{}\n\nPersisted:\n{}",
+        generated_output,
+        persisted_output,
+    );
+
+    // Ensure that secondary suggestions have also been persisted.
+    assert_eq!(
+        10,
+        generated_output
+            .lines()
+            .filter(|line| line.starts_with(char::is_numeric))
+            .map(|s| {
+                if let Some(pos) = s.find('(') {
+                    let name = &s[2..(pos - 1)];
+                    assert_eq!(Some(name), format!("{}", app.command(name)).lines().next());
+                } else {
+                    panic!("Missing ( in \"{}\"", s);
+                }
+            })
+            .count(),
+        "{}",
+        generated_output,
+    );
+}


### PR DESCRIPTION
Core integration tests send string commands and perform rudimentary asserts on the output, insofar as is possible with the random generator. More fine-grained testing will be left for unit tests. Eventually, once it becomes possible to seed data, we'll be able to be a bit more clever with our asserts.