### PR TITLE
Add "recent" command aliases for NPCs

### DIFF
--- a/core/src/app/context.rs
+++ b/core/src/app/context.rs
@@ -1,10 +1,12 @@
 use crate::world;
+use std::collections::HashMap;
 
 const RECENT_MAX_LEN: usize = 100;
 
 #[derive(Debug, Default)]
 pub struct Context {
     pub demographics: world::Demographics,
+    pub command_aliases: HashMap<String, String>,
 
     recent: Vec<world::Thing>,
 }

--- a/core/src/app/mod.rs
+++ b/core/src/app/mod.rs
@@ -23,7 +23,13 @@ impl App {
     }
 
     pub fn command(&mut self, input: &str) -> String {
-        if let Ok(command) = input.parse::<Command>() {
+        if let Ok(command) = self
+            .context
+            .command_aliases
+            .get(input)
+            .map_or(input, |s| s.as_str())
+            .parse::<Command>()
+        {
             command.run(&mut self.context, &mut self.rng)
         } else {
             format!("Unknown command: \"{}\"", input)

--- a/core/src/world/npc/mod.rs
+++ b/core/src/world/npc/mod.rs
@@ -52,15 +52,18 @@ pub fn command(species: &Option<Species>, context: &mut Context, rng: &mut impl 
     output.push_str(&format!("{}\n\nAlternatives:", npc.display_details()));
     context.push_recent(npc.into());
 
-    context.batch_push_recent(
-        (0..10)
-            .map(|i| {
-                let alt = Npc::generate(rng, &demographics);
-                output.push_str(&format!("\n{} {}", i, alt.display_summary()));
-                alt.into()
-            })
-            .collect(),
-    );
+    let recent = (0..10)
+        .map(|i| {
+            let alt = Npc::generate(rng, &demographics);
+            output.push_str(&format!("\n{} {}", i, alt.display_summary()));
+            context
+                .command_aliases
+                .insert(format!("{}", i), alt.name.value().unwrap().to_owned());
+            alt.into()
+        })
+        .collect();
+
+    context.batch_push_recent(recent);
 
     output
 }

--- a/core/tests/world_npc.rs
+++ b/core/tests/world_npc.rs
@@ -94,3 +94,37 @@ fn generated_content_is_persisted() {
         generated_output,
     );
 }
+
+#[test]
+fn numeric_aliases_exist_for_npcs() {
+    let mut app = app();
+
+    // Generate a data set to potentially interfere with the one being tested.
+    app.command("npc");
+
+    let generated_output = app.command("npc");
+
+    assert_eq!(
+        10,
+        generated_output
+            .lines()
+            .filter(|line| line.starts_with(char::is_numeric))
+            .map(|s| {
+                if let Some(pos) = s.find('(') {
+                    let digit = &s[0..1];
+                    let digit_output = app.command(digit);
+
+                    let name = &s[2..(pos - 1)];
+                    let name_output = app.command(name);
+
+                    assert_eq!(Some(name), digit_output.lines().next());
+                    assert_eq!(digit_output, name_output);
+                } else {
+                    panic!("Missing ( in \"{}\"", s);
+                }
+            })
+            .count(),
+        "{}",
+        generated_output,
+    );
+}


### PR DESCRIPTION
Previously, we would output multiple alternative names/profiles for generated NPCs, but there was no quick way to see more information about that NPC. Now, given the following input:

    Aerdeth Netyoive
    Species: half-elf (Half-Elvish)
    Gender: masculine (he/him)
    Age: young adult (24 years)
    Size: 5'7", 184 lbs (medium)

    Alternatives:
    0 Menny Tarkelby (middle-aged gnome, she/her)
    1 Asmund (adult human, he/him)
    2 Ndidi (middle-aged human, she/her)
    3 Suelo (human infant, she/her)
    4 Ulla Sympony (middle-aged gnome, she/her)
    5 Ilanis Hanali (elderly half-elf, she/her)
    6 Kennocha (adolescent human, she/her)
    7 Martin (human child, he/him)
    8 Achmed (adolescent human, he/him)
    9 Finnan Deephollow (geriatric halfling, he/him)

Typing "0" is now equivalent to typing "Menny Tarkelby".

This is not implemented for locations since not all locations currently have names, so there is no reliable way to see location details.