### PR TITLE
Fix Cloudflare building CSS files

### DIFF
--- a/web/build.sh
+++ b/web/build.sh
@@ -20,3 +20,4 @@ wasm-pack build --release
 cd www || exit
 npm install
 npm run build
+cp -v -- *.css dist/


### PR DESCRIPTION
Fix a build script bug where CSS files would not be bundled with the
final distribution to Cloudflare Pages. There's probably a more elegent
solution, but this works for now.