### PR TITLE
Embed Source Code Pro as a web font

### DIFF
--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,3 +1,6 @@
+* **Enhancement:** Adopted Source Code Pro for the interface font. Most
+  importantly, the common font ensures that the blocks in the logo are always
+  the same width.
 * **Bug:** Fixed the page not scrolling predictably. Scrolling behaviour should
   also respect browsers configured to prefer reduced motion.
 * **Enhancement:** Added equipment, all of the essentials like `Dagger` and

--- a/web/www/package-lock.json
+++ b/web/www/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@tarekraafat/autocomplete.js": "^10.2.6",
         "initiative-web": "file:../pkg",
-        "marked": "^2.1.3"
+        "marked": "^2.1.3",
+        "source-code-pro": "^2.38.0"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^9.0.1",
@@ -4920,6 +4921,11 @@
       "dependencies": {
         "ms": "^2.1.1"
       }
+    },
+    "node_modules/source-code-pro": {
+      "version": "2.38.0",
+      "resolved": "https://registry.npmjs.org/source-code-pro/-/source-code-pro-2.38.0.tgz",
+      "integrity": "sha512-JMXu7l3XrLREG17eEwY66ANG9716WTu6OeNvZfRKQKANEvbSERDZjk5AYTHeV6owQNPQTeiiW3ri2Ou93XFGvg=="
     },
     "node_modules/source-list-map": {
       "version": "2.0.1",
@@ -10181,6 +10187,11 @@
           }
         }
       }
+    },
+    "source-code-pro": {
+      "version": "2.38.0",
+      "resolved": "https://registry.npmjs.org/source-code-pro/-/source-code-pro-2.38.0.tgz",
+      "integrity": "sha512-JMXu7l3XrLREG17eEwY66ANG9716WTu6OeNvZfRKQKANEvbSERDZjk5AYTHeV6owQNPQTeiiW3ri2Ou93XFGvg=="
     },
     "source-list-map": {
       "version": "2.0.1",

--- a/web/www/package.json
+++ b/web/www/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "@tarekraafat/autocomplete.js": "^10.2.6",
     "initiative-web": "file:../pkg",
-    "marked": "^2.1.3"
+    "marked": "^2.1.3",
+    "source-code-pro": "^2.38.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^9.0.1",

--- a/web/www/public/style.css
+++ b/web/www/public/style.css
@@ -1,5 +1,5 @@
 * {
-    font-family: monospace;
+    font-family: "Source Code Pro";
     font-size: 100%;
     line-height: 1.2rem;
 }

--- a/web/www/webpack.config.js
+++ b/web/www/webpack.config.js
@@ -40,6 +40,10 @@ module.exports = {
     new CopyWebpackPlugin({
       patterns: [
         {
+          from: path.resolve(__dirname, "node_modules/source-code-pro"),
+          to: path.resolve(__dirname, "dist/source-code-pro"),
+        },
+        {
           from: path.resolve(__dirname, "public/*.css"),
           to: path.resolve(__dirname, "dist/[name].[contenthash][ext]"),
         },


### PR DESCRIPTION
The blocks that comprise the logo are now reliably the same width as the lettering in a *fixed-width font*, so no more weird skewed logos on Chrome for Android.

Resolves #65.