### PR TITLE
Fix truncated changelog

### DIFF
--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,3 +1,5 @@
+* **Bug:** Fixed `changelog` output being truncated and not always displaying 10
+  entries as intended.
 * **Enhancement:** Adopted Source Code Pro for the interface font. Most
   importantly, the common font ensures that the blocks in the logo are always
   the same width.

--- a/macros/src/changelog.rs
+++ b/macros/src/changelog.rs
@@ -8,10 +8,10 @@ pub fn run(input: TokenStream) -> Result<TokenStream, String> {
     let changelog = include_str!("../../data/changelog.md");
     let token_tree: TokenTree = Literal::string(
         changelog
-            .split_inclusive('\n')
+            .split_inclusive("\n*")
             .take(10)
             .collect::<String>()
-            .trim_end(),
+            .trim_end_matches(&['\n', '*'][..]),
     )
     .into();
 


### PR DESCRIPTION
Changelog was being truncated at line breaks in the source data. Fixed by taking 10 bullets' worth of data rather than 10 lines' worth.

Resolves #89.