### PR TITLE
Set fallback font

### DIFF
--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,3 +1,5 @@
+* **Bug:** Fix fallback font for browsers that don't support or haven't yet
+  loaded the default Source Code Pro font.
 * **Bug:** Fixed `changelog` output being truncated and not always displaying 10
   entries as intended.
 * **Enhancement:** Adopted Source Code Pro for the interface font. Most

--- a/web/www/public/style.css
+++ b/web/www/public/style.css
@@ -1,5 +1,5 @@
 * {
-    font-family: "Source Code Pro";
+    font-family: "Source Code Pro", monospace;
     font-size: 100%;
     line-height: 1.2rem;
 }


### PR DESCRIPTION
Set the fallback font to `monospace` to cover cases where Source Code Pro is unavailable/not loaded.

Resolves #88.