### PR TITLE
Rewrite inn name generation

### DIFF
--- a/core/src/world/location/building/inn.rs
+++ b/core/src/world/location/building/inn.rs
@@ -1,57 +1,202 @@
 use crate::world::{Demographics, Location};
-use rand::Rng;
-
-const INN_NAMES_1: [&str; 20] = [
-    "The Silver ",
-    "The Golden ",
-    "The Staggering ",
-    "The Laughing ",
-    "The Prancing ",
-    "The Gilded ",
-    "The Running ",
-    "The Howling ",
-    "The Slaughtered ",
-    "The Leering ",
-    "The Drunken ",
-    "The Leaping ",
-    "The Roaring ",
-    "The Frowning ",
-    "The Lonely ",
-    "The Wandering ",
-    "The Mysterious ",
-    "The Barking ",
-    "The Black ",
-    "The Gleaming ",
-];
-
-const INN_NAMES_2: [&str; 20] = [
-    "Eel", "Dolphin", "Dwarf", "Pegasus", "Pony", "Rose", "Stag", "Wolf", "Lamb", "Demon", "Goat",
-    "Spirit", "Horde", "Jester", "Mountain", "Eagle", "Satyr", "Dog", "Spider", "Star",
-];
+use rand::prelude::*;
 
 pub fn generate(location: &mut Location, rng: &mut impl Rng, _demographics: &Demographics) {
-    location.name.replace_with(|prev| {
-        let mut name = prev.unwrap_or_default();
-        name.clear();
-        name.push_str(INN_NAMES_1[rng.gen_range(0..INN_NAMES_1.len())]);
-        name.push_str(INN_NAMES_2[rng.gen_range(0..INN_NAMES_2.len())]);
-        name.shrink_to_fit();
-        name
-    });
+    location.name.replace_with(|_| name(rng));
+}
 
-    location.description.replace_with(|_| {
-        match rng.gen_range(1..=20) {
-            1..=5 => "Quiet, low-key bar",
-            6..=9 => "Raucous dive",
-            10 => "Thieves' guild hangout",
-            11 => "Gathering place for a secret society",
-            12..=13 => "Upper-class dining club",
-            14..=15 => "Gambling den",
-            16..=17 => "Caters to a specific species or guild",
-            18 => "Members-only club",
-            19..=20 => "Members-only club",
+fn name(rng: &mut impl Rng) -> String {
+    match rng.gen_range(0..6) {
+        0 => format!("The {}", thing(rng)),
+        1 => {
+            let (profession, s) = plural(profession(rng));
+            format!("{}{} Arms", profession, s)
+        }
+        2..=3 => {
+            let (thing1, thing2) = thing_thing(rng);
+            format!("{} and {}", thing1, thing2)
+        }
+        4 => format!("The {} {}", adjective(rng), thing(rng)),
+        5 => {
+            let (thing, s) = plural(thing(rng));
+            format!("{} {}{}", number(rng), thing, s)
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn thing(rng: &mut impl Rng) -> &'static str {
+    match rng.gen_range(0..5) {
+        0 => animal(rng),
+        1 => enemy(rng),
+        2 => food(rng),
+        3 => profession(rng),
+        4 => symbol(rng),
+        _ => unreachable!(),
+    }
+}
+
+fn thing_thing(rng: &mut impl Rng) -> (&'static str, &'static str) {
+    // We're more likely to have two things in the same category.
+    let (thing1, thing2) = if rng.gen_bool(0.5) {
+        match rng.gen_range(0..5) {
+            0 => (animal(rng), animal(rng)),
+            1 => (enemy(rng), enemy(rng)),
+            2 => (food(rng), food(rng)),
+            3 => (profession(rng), profession(rng)),
+            4 => (symbol(rng), symbol(rng)),
             _ => unreachable!(),
         }
-        .to_string()
-    });
+    } else {
+        (thing(rng), thing(rng))
+    };
+
+    // 50% chance of rolling again if we don't get two words starting with the same letter.
+    // (This is distinct from 50% chance of repeated letters, since the next try probably also
+    // won't have repetition.)
+    if thing1 == thing2
+        || rng.gen_bool(0.5)
+            && thing1
+                .chars()
+                .next()
+                .map(|c| !thing2.starts_with(c))
+                .unwrap_or(false)
+    {
+        thing_thing(rng)
+    } else {
+        (thing1, thing2)
+    }
+}
+
+fn plural(word: &str) -> (&str, &str) {
+    match word {
+        "Goose" => ("geese", ""),
+        "Key" => ("key", "s"),
+        "Beef" | "Carp" | "Cod" | "Deer" | "Perch" | "Potatoes" | "Sheep" | "Squid" => (word, ""),
+        s if s.ends_with('f') => (&word[..(word.len() - 1)], "ves"),
+        s if s.ends_with("ey") => (&word[..(word.len() - 2)], "ies"),
+        s if s.ends_with('y') => (&word[..(word.len() - 1)], "ies"),
+        s if s.ends_with(&['s', 'x'][..]) => (word, "es"),
+        _ => (word, "s"),
+    }
+}
+
+fn adjective(rng: &mut impl Rng) -> &'static str {
+    #[rustfmt::skip]
+    const ADJECTIVES: &[&str] = &[
+        "Blue", "Bronze", "Brown", "Burgundy", "Driven", "Enchanted", "Gold", "Green", "Grey",
+        "Grouchy", "Hallowed", "Happy", "Hidden", "Hungry", "Jovial", "Lone", "Lost", "Lucky",
+        "Merry", "Moody", "Morose", "Orange", "Purple", "Red", "Silent", "Silver", "Thirsty",
+        "Wasted", "Wild",
+    ];
+    ADJECTIVES[rng.gen_range(0..ADJECTIVES.len())]
+}
+
+fn animal(rng: &mut impl Rng) -> &'static str {
+    #[rustfmt::skip]
+    const ANIMALS: &[&str] = &[
+        "Antelope", "Ape", "Baboon", "Badger", "Bat", "Bear", "Beaver", "Bee", "Beetle", "Boar",
+        "Camel", "Carp", "Cat", "Cod", "Cormorant", "Cow", "Crab", "Deer", "Dog", "Dolphin",
+        "Donkey", "Dove", "Dragonfly", "Duck", "Eagle", "Eel", "Elephant", "Elk", "Ermine", "Fox",
+        "Frog", "Goat", "Goose", "Hare", "Hart", "Hawk", "Hedgehog", "Heron", "Herring", "Horse",
+        "Hound", "Hyena", "Jackal", "Lamb", "Leopard", "Lion", "Magpie", "Mermaid", "Mole",
+        "Octopus", "Osprey", "Otter", "Owl", "Panther", "Peacock", "Pelican", "Perch", "Phoenix",
+        "Pony", "Porcupine", "Rabbit", "Ram", "Rat", "Raven", "Salamander", "Salmon", "Scorpion",
+        "Seagull", "Seal", "Shark", "Sheep", "Snake", "Spider", "Squid", "Squirrel", "Stag",
+        "Stoat", "Stork", "Swan", "Tiger", "Toad", "Tortoise", "Trout", "Turkey", "Turtle",
+        "Unicorn", "Vulture", "Weasel", "Whale", "Whelk", "Wolf",
+    ];
+    ANIMALS[rng.gen_range(0..ANIMALS.len())]
+}
+
+fn enemy(rng: &mut impl Rng) -> &'static str {
+    #[rustfmt::skip]
+    const ENEMIES: &[&str] = &[
+        "Angel", "Bandit", "Brigand", "Centaur", "Chimera", "Demon", "Devil", "Dragon", "Fairy",
+        "Ghost", "Giant", "Goblin", "Gorgon", "Gremlin", "Hag", "Harpy", "Hydra", "Imp", "Kappa",
+        "Lich", "Manticore", "Minotaur", "Necromancer", "Oni", "Orc", "Peryton", "Pirate", "Roc",
+        "Satyr", "Seraph", "Siren", "Sorcerer", "Sphinx", "Thief", "Trickster", "Troll", "Unicorn",
+        "Vampire", "Werewolf", "Witch", "Wyvern", "Zombie",
+    ];
+    ENEMIES[rng.gen_range(0..ENEMIES.len())]
+}
+
+fn food(rng: &mut impl Rng) -> &'static str {
+    #[rustfmt::skip]
+    const FOODS: &[&str] = &[
+        "Barley", "Barrel", "Beef", "Beer", "Bread", "Cask", "Cheese", "Hop", "Keg", "Malt",
+        "Mead", "Meat", "Mutton", "Pint", "Pork", "Potatoes", "Rye", "Tun", "Veal", "Venison",
+        "Vine",
+    ];
+    FOODS[rng.gen_range(0..FOODS.len())]
+}
+
+fn number(rng: &mut impl Rng) -> &'static str {
+    #[rustfmt::skip]
+    const NUMBERS: &[&str] = &["Three", "Five", "Seven", "Ten"];
+    NUMBERS[rng.gen_range(0..NUMBERS.len())]
+}
+
+fn profession(rng: &mut impl Rng) -> &'static str {
+    #[rustfmt::skip]
+    const PROFESSIONS: &[&str] = &[
+        "Adventurer", "Baker", "Beggar", "Blacksmith", "Brewer", "Bricklayer", "Builder",
+        "Butcher", "Carpenter", "Conjurer", "Cooper", "Diviner", "Enchanter", "Evoker", "Farrier",
+        "Ferryman", "Fisherman", "Glazier", "Illusionist", "Knight", "Mage", "Magician", "Mason",
+        "Miller", "Plumber", "Porter", "Printer", "Roper", "Sailor", "Shipwright", "Smith",
+        "Soldier", "Waterman", "Warrior", "Wizard",
+    ];
+    PROFESSIONS[rng.gen_range(0..PROFESSIONS.len())]
+}
+
+fn symbol(rng: &mut impl Rng) -> &'static str {
+    #[rustfmt::skip]
+    const SYMBOLS: &[&str] = &[
+        "Abbey", "Anchor", "Anvil", "Arrow", "Axe", "Belfry", "Bell", "Book", "Buckle", "Cap",
+        "Castle", "Column", "Crescent", "Crown", "Drum", "Feather", "Foil", "Hammer", "Harp",
+        "Harrow", "Helmet", "Horseshoe", "Key", "Lance", "Lance", "Locket", "Mace", "Mill",
+        "Mitre", "Moon", "Nail", "Oar", "Phalactary", "Rake", "Rook", "Scale", "Sceptre", "Scythe",
+        "Ship", "Shovel", "Spear", "Spur", "Star", "Steeple", "Sun", "Sword", "Thunderbolt",
+        "Tower", "Trumpet", "Wand", "Wheel",
+    ];
+    SYMBOLS[rng.gen_range(0..SYMBOLS.len())]
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn name_test() {
+        let mut rng = SmallRng::seed_from_u64(0);
+
+        assert_eq!(
+            [
+                "Mutton and Malt",
+                "Wizards Arms",
+                "The Column",
+                "Coopers Arms",
+                "The Orange Unicorn",
+                "Pork and Tun",
+                "The Turtle",
+                "Bricklayers Arms",
+                "The Orange Pint",
+                "The Hedgehog",
+                "The Star",
+                "Beer and Cask",
+                "Smiths Arms",
+                "The Hallowed Crown",
+                "The Thirsty Porter",
+                "Hyena and Demon",
+                "The Silver Beer",
+                "Masons Arms",
+                "Three Kegs",
+                "Blacksmiths Arms",
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>(),
+            (0..20).map(|_| name(&mut rng)).collect::<Vec<String>>(),
+        );
+    }
 }

--- a/core/src/world/location/building/mod.rs
+++ b/core/src/world/location/building/mod.rs
@@ -111,8 +111,8 @@ mod test {
     fn generate_inn_test() {
         generate_test_builder(
             generate_inn,
-            Field::from("The Gleaming Demon").unlocked(),
-            Field::from("Thieves' guild hangout").unlocked(),
+            Field::from("Mutton and Malt").unlocked(),
+            Field::from("Previous description").unlocked(),
         );
     }
 

--- a/core/tests/world_location.rs
+++ b/core/tests/world_location.rs
@@ -34,7 +34,7 @@ fn generated_content_is_persisted() {
     // # The Roaring Spirit
     // *inn*
     //
-    // Gathering place for a secret society
+    // _The Roaring Spirit has not yet been saved. Use ~save~ to save it to your journal._
     //
     // *Alternatives:*\
     // 0 The Lonely Rose, an inn\
@@ -60,13 +60,13 @@ fn generated_content_is_persisted() {
         persisted_output.lines().next(),
     );
     assert_eq!(
-        6,
+        4,
         generated_output
             .lines()
             .zip(persisted_output.lines())
             .enumerate()
             .map(|(i, (generated, persisted))| {
-                if i == 5 {
+                if i == 3 {
                     assert_eq!("*Alternatives:* \\", generated);
                     assert_eq!(
                         format!(

--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,3 +1,5 @@
+* **Enhancement:** Rewrite inn name generator to provide a greater variety of
+  results.
 * **New:** New command `journal` lists everything you've saved to your journal.
 * **Enhancement:** Autocomplete suggestions when loading a thing will include
   a brief summary of that thing, eg. "adult human, they/them".


### PR DESCRIPTION
Update generator to no longer rely on WotC material. It also provides a much more varied set of results.

Descriptions are no longer provided (for now).

Resolves #109.