### PR TITLE
Implement tab autocomplete

### DIFF
--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,3 +1,6 @@
+* **Enhancement:** Tab key can be used to select an autocomplete option without
+  submitting. If the selection includes a bracketed phrase like `save [name]`,
+  the autofill will update to suggest ways to complete the phrase.
 * **New:** Time! See the current time with `now`, advance and rewind time with
   `+1d`, `-1h`, etc. Time does not yet persist between sessions.
 * **Enhancement:** You can now delete entries from your journal with


### PR DESCRIPTION
* disable tab key default behaviour
* tab key fills autocomplete without submitting #122
* autocomplete search query now ignores text after "["
* fix bug with multiple submissions under certain circumstances #116 
* only focus the input field when pressing input keys (eg. `a`) without ctrl or meta modifiers #92 