### PR TITLE
Tab complete supports partial fills

### DIFF
--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,7 +1,9 @@
+* **Enhancement:** Tab key now fills as much text as possible. Try typing "weap"
+  and pressing tab.
 * **New:** There's a Discord server now! See the link in the welcome message to
   join.
 * **Enhancement:** Tab key can be used to select an autocomplete option without
-  submitting. If the selection includes a bracketed phrase like `save [name]`,
+  submitting. If the selection includes a bracketed phrase like `load [name]`,
   the autofill will update to suggest ways to complete the phrase.
 * **New:** Time! See the current time with `now`, advance and rewind time with
   `+1d`, `-1h`, etc. Time does not yet persist between sessions.

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -130,16 +130,31 @@ window.addEventListener("keydown", (event) => {
   if (event.key === "Tab") {
     event.preventDefault();
 
-    if (autoCompleteJS.isOpen &&
-      (autoCompleteJS.feedback.results.length == 1 || autoCompleteJS.cursor > -1))
-    {
-      let index = Math.max(autoCompleteJS.cursor, 0);
+    if (autoCompleteJS.isOpen) {
+      if (autoCompleteJS.cursor > -1) {
+        selectBracketedExpression(
+          autoCompleteJS.feedback.results[autoCompleteJS.cursor].value.suggestion
+        );
 
-      selectBracketedExpression(
-        autoCompleteJS.feedback.results[index].value.suggestion
-      );
+        autoCompleteJS.start();
+      } else {
+        const commonPrefix = autoCompleteJS.feedback.results
+          .map((result) => result.value.suggestion)
+          .reduce((a, b) => {
+            let acc = "";
+            for (let i = 0; i < Math.min(a.length, b.length); i++) {
+              if (a[i] == b[i]) {
+                acc += a[i];
+              } else {
+                break;
+              }
+            }
+            return acc;
+          });
 
-      autoCompleteJS.start();
+        selectBracketedExpression(commonPrefix);
+        autoCompleteJS.start();
+      }
     }
   } else if (event.key.length === 1 && !event.ctrlKey && !event.metaKey) {
     promptElement.focus();


### PR DESCRIPTION
The tab key now fills content if there are common characters among all suggestions.

Resolves #135.