### PR TITLE
Add dice roller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,16 +56,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "caith"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1415036b1c1bd665d42d63cf2a70726718da12652c712dd6c5e02608e202971"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "rand",
+]
 
 [[package]]
 name = "cfg-if"
@@ -88,6 +132,21 @@ dependencies = [
  "cfg-if 0.1.10",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "futures"
@@ -184,6 +243,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +287,7 @@ name = "initiative-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "caith",
  "initiative-macros",
  "rand",
  "rand_distr",
@@ -335,6 +404,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +479,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +507,49 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1",
 ]
 
 [[package]]
@@ -494,6 +618,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
@@ -523,6 +648,15 @@ checksum = "051b398806e42b9cd04ad9ec8f81e355d0a382c543ac6672c62f5a5b452ef142"
 dependencies = [
  "num-traits",
  "rand",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -607,6 +741,18 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "fake-simd",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -707,6 +853,18 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-xid"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
+caith = "4.2"
 rand = { version = "0.8", default-features = false, features = ["std", "small_rng"] }
 rand_distr = { version = "0.4", default-features = false }
 serde = { version = "1.0", features = ["derive"] }

--- a/core/src/app/command/app.rs
+++ b/core/src/app/command/app.rs
@@ -1,13 +1,16 @@
 use crate::app::{autocomplete_phrase, AppMeta, Runnable};
 use async_trait::async_trait;
-use initiative_macros::{changelog, WordList};
+use caith::Roller;
+use initiative_macros::changelog;
+use std::str::FromStr;
 
-#[derive(Clone, Debug, PartialEq, WordList)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum AppCommand {
     About,
     Changelog,
     Debug,
     Help,
+    Roll(String),
 }
 
 impl AppCommand {
@@ -17,6 +20,7 @@ impl AppCommand {
             Self::Changelog => "show latest updates",
             Self::Debug => "",
             Self::Help => "how to use initiative.sh",
+            Self::Roll(_) => "roll eg. 8d6 or d20+3",
         }
     }
 }
@@ -33,6 +37,23 @@ impl Runnable for AppCommand {
             Self::Help => include_str!("../../../../data/help.md")
                 .trim_end()
                 .to_string(),
+            Self::Roll(s) => Roller::new(s)
+                .ok()
+                .map(|r| r.roll_with(&mut app_meta.rng).ok())
+                .flatten()
+                .map(|result| {
+                    result
+                        .to_string()
+                        .trim_end()
+                        .replace('\n', "\\\n")
+                        .replace('`', "")
+                })
+                .ok_or_else(|| {
+                    format!(
+                        "\"{}\" is not a valid dice formula. See `help` for some examples.",
+                        s
+                    )
+                })?,
         })
     }
 
@@ -40,18 +61,44 @@ impl Runnable for AppCommand {
         input.parse().map(|c| vec![c]).unwrap_or_default()
     }
 
-    fn autocomplete(input: &str, _app_meta: &AppMeta) -> Vec<(String, String)> {
-        autocomplete_phrase(
-            input,
-            &mut Self::get_words().iter().filter(|s| s != &&"debug"),
-        )
-        .drain(..)
-        .filter_map(|s| {
-            s.parse::<Self>()
-                .ok()
-                .map(|c| (s, c.summarize().to_string()))
+    fn autocomplete(input: &str, app_meta: &AppMeta) -> Vec<(String, String)> {
+        if input.is_empty() {
+            return Vec::new();
+        }
+
+        autocomplete_phrase(input, &mut ["about", "changelog", "help"].iter())
+            .drain(..)
+            .filter_map(|s| s.parse::<Self>().ok().map(|c| (s, c)))
+            .chain(
+                ["roll"]
+                    .iter()
+                    .filter(|s| s.starts_with(input))
+                    .filter_map(|s| {
+                        let suggestion = format!("{} [dice]", s);
+                        Self::parse_input(&suggestion, app_meta)
+                            .drain(..)
+                            .next()
+                            .map(|command| (suggestion, command))
+                    }),
+            )
+            .map(|(s, c)| (s, c.summarize().to_string()))
+            .collect()
+    }
+}
+
+impl FromStr for AppCommand {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "about" => Self::About,
+            "changelog" => Self::Changelog,
+            "debug" => Self::Debug,
+            "help" => Self::Help,
+            s if s.starts_with("roll ") => Self::Roll(s[5..].to_string()),
+            s if Roller::new(s).map_or(false, |r| r.roll().is_ok()) => Self::Roll(s.to_string()),
+            _ => return Err(()),
         })
-        .collect()
     }
 }
 
@@ -99,6 +146,14 @@ mod test {
                 AppCommand::autocomplete(word, &app_meta),
             )
         });
+
+        assert_eq!(
+            vec![(
+                "roll [dice]".to_string(),
+                "roll eg. 8d6 or d20+3".to_string(),
+            )],
+            AppCommand::autocomplete("roll", &app_meta),
+        );
 
         // Debug should be excluded from the autocomplete results.
         assert_eq!(

--- a/core/tests/app.rs
+++ b/core/tests/app.rs
@@ -85,6 +85,25 @@ fn init() {
 }
 
 #[test]
+fn roll() {
+    let mut app = sync_app();
+
+    let output = app.command("roll d1").unwrap();
+    assert_eq!("[1] = **1**", output);
+
+    let output = app.command("(d1)^2").unwrap();
+    assert_eq!("[1] = **1**\\\n[1] = **1**", output);
+
+    let output = app.command("roll banana").unwrap_err();
+    assert_eq!(
+        "\"banana\" is not a valid dice formula. See `help` for some examples.",
+        output,
+    );
+
+    assert_ne!(app.command("roll 100d1000"), app.command("roll 100d1000"));
+}
+
+#[test]
 fn unknown() {
     assert_eq!(
         "Unknown command: \"blah blah\"",

--- a/core/tests/reference.rs
+++ b/core/tests/reference.rs
@@ -60,7 +60,7 @@ fn item() {
 *Weapon (Simple Ranged)*
 
 **Cost:** 25 gp\\
-**Damage:** 1d8 piercing\\
+**Damage:** `1d8` piercing\\
 **Properties:** Ammunition (range 80/320), loading, two-handed\\
 **Weight:** 5 lbs
 
@@ -81,34 +81,34 @@ fn weapons() {
 
 | Name | Cost | Damage | Weight | Properties |
 |---|--:|---|--:|---|
-| `Battleaxe` | 10 gp | 1d8 slashing | 4 lb. | Versatile (1d10) |
-| `Club` | 1 sp | 1d4 bludgeoning | 2 lb. | Light, monk |
-| `Dagger` | 2 gp | 1d4 piercing | 1 lb. | Finesse, light, monk, thrown (range 20/60) |
-| `Flail` | 10 gp | 1d8 bludgeoning | 2 lb. | — |
-| `Glaive` | 20 gp | 1d10 slashing | 6 lb. | Heavy, reach, two-handed |
-| `Greataxe` | 30 gp | 1d12 slashing | 7 lb. | Heavy, two-handed |
-| `Greatclub` | 2 sp | 1d8 bludgeoning | 10 lb. | Two-Handed |
-| `Greatsword` | 50 gp | 2d6 slashing | 6 lb. | Heavy, two-handed |
-| `Halberd` | 20 gp | 1d10 slashing | 6 lb. | Heavy, reach, two-handed |
-| `Handaxe` | 5 gp | 1d6 slashing | 2 lb. | Light, monk, thrown (range 20/60) |
-| `Javelin` | 5 sp | 1d6 piercing | 2 lb. | Monk, thrown (range 30/120) |
-| `Lance` | 10 gp | 1d12 piercing | 6 lb. | Reach, special |
-| `Light Hammer` | 2 gp | 1d4 bludgeoning | 2 lb. | Light, monk, thrown (range 20/60) |
-| `Longsword` | 15 gp | 1d8 slashing | 3 lb. | Versatile (1d10) |
-| `Mace` | 5 gp | 1d6 bludgeoning | 4 lb. | Monk |
-| `Maul` | 10 gp | 2d6 bludgeoning | 10 lb. | Heavy, two-handed |
-| `Morningstar` | 15 gp | 1d8 piercing | 4 lb. | — |
-| `Pike` | 5 gp | 1d10 piercing | 18 lb. | Heavy, reach, two-handed |
-| `Quarterstaff` | 2 sp | 1d6 bludgeoning | 4 lb. | Monk, versatile (1d8) |
-| `Rapier` | 25 gp | 1d8 piercing | 2 lb. | Finesse |
-| `Scimitar` | 25 gp | 1d6 slashing | 3 lb. | Finesse, light |
-| `Shortsword` | 10 gp | 1d6 piercing | 2 lb. | Finesse, light, monk |
-| `Sickle` | 1 gp | 1d4 slashing | 2 lb. | Light, monk |
-| `Spear` | 1 gp | 1d6 piercing | 3 lb. | Monk, thrown (range 20/60), versatile (1d8) |
-| `Trident` | 5 gp | 1d6 slashing | 4 lb. | Thrown (range 20/60), versatile (1d8) |
-| `War Pick` | 5 gp | 1d8 piercing | 2 lb. | — |
-| `Warhammer` | 15 gp | 1d8 bludgeoning | 2 lb. | Versatile (1d10) |
-| `Whip` | 2 gp | 1d4 slashing | 3 lb. | Finesse, reach |
+| `Battleaxe` | 10 gp | `1d8` slashing | 4 lb. | Versatile (`1d10`) |
+| `Club` | 1 sp | `1d4` bludgeoning | 2 lb. | Light, monk |
+| `Dagger` | 2 gp | `1d4` piercing | 1 lb. | Finesse, light, monk, thrown (range 20/60) |
+| `Flail` | 10 gp | `1d8` bludgeoning | 2 lb. | — |
+| `Glaive` | 20 gp | `1d10` slashing | 6 lb. | Heavy, reach, two-handed |
+| `Greataxe` | 30 gp | `1d12` slashing | 7 lb. | Heavy, two-handed |
+| `Greatclub` | 2 sp | `1d8` bludgeoning | 10 lb. | Two-Handed |
+| `Greatsword` | 50 gp | `2d6` slashing | 6 lb. | Heavy, two-handed |
+| `Halberd` | 20 gp | `1d10` slashing | 6 lb. | Heavy, reach, two-handed |
+| `Handaxe` | 5 gp | `1d6` slashing | 2 lb. | Light, monk, thrown (range 20/60) |
+| `Javelin` | 5 sp | `1d6` piercing | 2 lb. | Monk, thrown (range 30/120) |
+| `Lance` | 10 gp | `1d12` piercing | 6 lb. | Reach, special |
+| `Light Hammer` | 2 gp | `1d4` bludgeoning | 2 lb. | Light, monk, thrown (range 20/60) |
+| `Longsword` | 15 gp | `1d8` slashing | 3 lb. | Versatile (`1d10`) |
+| `Mace` | 5 gp | `1d6` bludgeoning | 4 lb. | Monk |
+| `Maul` | 10 gp | `2d6` bludgeoning | 10 lb. | Heavy, two-handed |
+| `Morningstar` | 15 gp | `1d8` piercing | 4 lb. | — |
+| `Pike` | 5 gp | `1d10` piercing | 18 lb. | Heavy, reach, two-handed |
+| `Quarterstaff` | 2 sp | `1d6` bludgeoning | 4 lb. | Monk, versatile (`1d8`) |
+| `Rapier` | 25 gp | `1d8` piercing | 2 lb. | Finesse |
+| `Scimitar` | 25 gp | `1d6` slashing | 3 lb. | Finesse, light |
+| `Shortsword` | 10 gp | `1d6` piercing | 2 lb. | Finesse, light, monk |
+| `Sickle` | 1 gp | `1d4` slashing | 2 lb. | Light, monk |
+| `Spear` | 1 gp | `1d6` piercing | 3 lb. | Monk, thrown (range 20/60), versatile (`1d8`) |
+| `Trident` | 5 gp | `1d6` slashing | 4 lb. | Thrown (range 20/60), versatile (`1d8`) |
+| `War Pick` | 5 gp | `1d8` piercing | 2 lb. | — |
+| `Warhammer` | 15 gp | `1d8` bludgeoning | 2 lb. | Versatile (`1d10`) |
+| `Whip` | 2 gp | `1d4` slashing | 3 lb. | Finesse, reach |
 
 *This listing is Open Game Content subject to the `Open Game License`.*",
         output,

--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,3 +1,5 @@
+* **New:** Rectified a major oversight for a D&D app: added a dice roller! Get
+  your `Fireball` on with `roll 8d6` or use `roll (d4+1)^3` for `Magic Missile`.
 * **Enhancement:** Rewrote name generators to work syllable by syllable. You
   might end up with some awkward names, but you'll have access to a much greater
   variety of names as a result.

--- a/data/help.md
+++ b/data/help.md
@@ -38,3 +38,15 @@ The journal also tracks the current time. When you start a game, the time is day
 * `-[number][d, h, m, s, or r]` rewinds time by the same.
 * You can skip the number to advance or rewind time by a single unit, so `+d`
   advances to the next day.
+
+Of course, no DM tool would be complete without a dice roller: `roll [formula]`
+or simply `[formula]`.
+Some examples to get you started:
+
+* `8d6: Fireball`
+* `d20+3: dexterity check with +3 bonus`
+* `2d20k1+5: +5 attack roll with disadvantage` (k = keep low)
+* `2d20d1+5: +5 attack roll with advantage` (d = drop low)
+* `(d4+1)^3: magic missile` (rolls 3 times)
+* See [the documentation](https://github.com/Geobert/caith/blob/v4.2.0/README.md#syntax)
+  for more options.


### PR DESCRIPTION
* Add a dice roller from the caith crate.
* Eager parses dice formulae without requiring the `roll` command.
* Detects dice formulae in reference output (eg. spells) and linkifies them accordingly.

Resolves #155.