### PR TITLE
Focus input field on click/tap

### DIFF
--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,3 +1,6 @@
+* **Enhancement:** Input field is now focused whenever you click or tap anywhere
+  on the page, improving the "stickiness" of the experience, especially on
+  mobile.
 * **Enhancement:** Changes to the game `time` are now saved between sessions.
   There's still some work to do before this feature is worth featuring more
   prominently, but at least it's in a usable state now.

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -183,7 +183,9 @@ window.addEventListener("keydown", (event) => {
   }
 });
 
-outputElement.addEventListener("click", async (event) => {
+window.addEventListener("click", async (event) => {
+  promptElement.focus();
+
   if (event.target.nodeName === "CODE") {
     await runCommand(event.target.innerText);
   }


### PR DESCRIPTION
Update focus to the input field every time the page is clicked or tapped, which should particularly improve the mobile experience and overall "stickiness" of the input.

Resolves #162.