### PR TITLE
Do not focus input when clicking links

### DIFF
--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,3 +1,5 @@
+* **Enhancement:** On mobile, the keyboard will no longer pop up when clicking a
+  link.
 * **Enhancement:** Input field is now focused whenever you click or tap anywhere
   on the page, improving the "stickiness" of the experience, especially on
   mobile.

--- a/web/js/index.html
+++ b/web/js/index.html
@@ -60,7 +60,7 @@
       <p>initiative.sh is a storytelling aid for game masters. It's designed to
       support the creative process as your sessions evolve in real time.</p>
 
-      <p>Please join the conversation
+      <p>This project is under active development. Please join the conversation
       <a href="https://discord.gg/ZrqJPpxXVZ" target="_blank">on Discord</a> or
       contact <a href="mailto:support@initiative.sh">support@initiative.sh</a>
       to help me make initiative.sh the best tool in your DM toolbox. Your use

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -184,10 +184,10 @@ window.addEventListener("keydown", (event) => {
 });
 
 window.addEventListener("click", async (event) => {
-  promptElement.focus();
-
   if (event.target.nodeName === "CODE") {
     await runCommand(event.target.innerText);
+  } else {
+    promptElement.focus();
   }
 });
 


### PR DESCRIPTION
Update logic to no longer focus the input field and therefore pop up the keyboard whenever a link is clicked.

Dials the "stickiness" from #163 back from 11 to 10.