### PR TITLE
Fix "trans" terminology to "non-binary"

### DIFF
--- a/core/src/storage/command.rs
+++ b/core/src/storage/command.rs
@@ -427,7 +427,7 @@ mod test {
             Npc {
                 name: "Potato Johnson".into(),
                 species: Species::Elf.into(),
-                gender: Gender::Trans.into(),
+                gender: Gender::NonBinaryThey.into(),
                 age: Age::Adult(0).into(),
                 ..Default::default()
             }

--- a/core/src/world/npc/command.rs
+++ b/core/src/world/npc/command.rs
@@ -20,7 +20,7 @@ pub fn command(species: &Option<Species>, app_meta: &mut AppMeta) -> String {
             output.push_str(&format!(
                 "\n\n_{} has not yet been saved. Use ~save~ to save {} to your `journal`._",
                 name,
-                npc.gender.value().unwrap_or(&Gender::Trans).them(),
+                npc.gender.value().unwrap_or(&Gender::NonBinaryThey).them(),
             ));
             app_meta.command_aliases.insert(CommandAlias::literal(
                 "save".to_string(),

--- a/core/src/world/npc/ethnicity/dragonborn.rs
+++ b/core/src/world/npc/ethnicity/dragonborn.rs
@@ -183,7 +183,7 @@ mod test_generate_for_ethnicity {
         let age = Age::Adult(0);
         let m = Gender::Masculine;
         let f = Gender::Feminine;
-        let t = Gender::Trans;
+        let t = Gender::NonBinaryThey;
 
         assert_eq!(
             [

--- a/core/src/world/npc/ethnicity/dwarvish.rs
+++ b/core/src/world/npc/ethnicity/dwarvish.rs
@@ -212,7 +212,7 @@ mod test_generate_for_ethnicity {
         let age = Age::Adult(0);
         let m = Gender::Masculine;
         let f = Gender::Feminine;
-        let t = Gender::Trans;
+        let t = Gender::NonBinaryThey;
 
         assert_eq!(
             [

--- a/core/src/world/npc/ethnicity/elvish.rs
+++ b/core/src/world/npc/ethnicity/elvish.rs
@@ -231,7 +231,7 @@ mod test_generate_for_ethnicity {
         let adult = Age::Adult(0);
         let m = Gender::Masculine;
         let f = Gender::Feminine;
-        let t = Gender::Trans;
+        let t = Gender::NonBinaryThey;
 
         assert_eq!(
             [

--- a/core/src/world/npc/ethnicity/gnomish.rs
+++ b/core/src/world/npc/ethnicity/gnomish.rs
@@ -204,7 +204,7 @@ mod test_generate_for_ethnicity {
         let age = Age::Adult(0);
         let m = Gender::Masculine;
         let f = Gender::Feminine;
-        let t = Gender::Trans;
+        let t = Gender::NonBinaryThey;
 
         assert_eq!(
             [

--- a/core/src/world/npc/ethnicity/halfling.rs
+++ b/core/src/world/npc/ethnicity/halfling.rs
@@ -211,7 +211,7 @@ mod test_generate_for_ethnicity {
         let age = Age::Adult(0);
         let m = Gender::Masculine;
         let f = Gender::Feminine;
-        let t = Gender::Trans;
+        let t = Gender::NonBinaryThey;
 
         assert_eq!(
             [

--- a/core/src/world/npc/ethnicity/human.rs
+++ b/core/src/world/npc/ethnicity/human.rs
@@ -216,7 +216,7 @@ mod test_generate_for_ethnicity {
         let age = Age::Adult(0);
         let m = Gender::Masculine;
         let f = Gender::Feminine;
-        let t = Gender::Trans;
+        let t = Gender::NonBinaryThey;
 
         assert_eq!(
             [

--- a/core/src/world/npc/ethnicity/orcish.rs
+++ b/core/src/world/npc/ethnicity/orcish.rs
@@ -174,7 +174,7 @@ mod test_generate_for_ethnicity {
         let age = Age::Adult(0);
         let m = Gender::Masculine;
         let f = Gender::Feminine;
-        let t = Gender::Trans;
+        let t = Gender::NonBinaryThey;
 
         assert_eq!(
             [

--- a/core/src/world/npc/ethnicity/tiefling.rs
+++ b/core/src/world/npc/ethnicity/tiefling.rs
@@ -144,7 +144,7 @@ mod test_generate_for_ethnicity {
         let adult = Age::Adult(0);
         let m = Gender::Masculine;
         let f = Gender::Feminine;
-        let t = Gender::Trans;
+        let t = Gender::NonBinaryThey;
 
         assert_eq!(
             [

--- a/core/src/world/npc/gender.rs
+++ b/core/src/world/npc/gender.rs
@@ -5,7 +5,7 @@ use std::fmt;
 pub enum Gender {
     Masculine,
     Feminine,
-    Trans,
+    NonBinaryThey,
     Neuter,
 }
 
@@ -15,7 +15,7 @@ impl Gender {
             Self::Feminine => "feminine",
             Self::Masculine => "masculine",
             Self::Neuter => "neuter",
-            Self::Trans => "trans",
+            Self::NonBinaryThey => "non-binary",
         }
     }
 
@@ -24,7 +24,7 @@ impl Gender {
             Self::Feminine => "she/her",
             Self::Masculine => "he/him",
             Self::Neuter => "it",
-            Self::Trans => "they/them",
+            Self::NonBinaryThey => "they/them",
         }
     }
 
@@ -33,7 +33,7 @@ impl Gender {
             Self::Feminine => "she",
             Self::Masculine => "he",
             Self::Neuter => "it",
-            Self::Trans => "they",
+            Self::NonBinaryThey => "they",
         }
     }
 
@@ -42,7 +42,7 @@ impl Gender {
             Self::Feminine => "She",
             Self::Masculine => "He",
             Self::Neuter => "It",
-            Self::Trans => "They",
+            Self::NonBinaryThey => "They",
         }
     }
 
@@ -51,7 +51,7 @@ impl Gender {
             Self::Feminine => "she's",
             Self::Masculine => "he's",
             Self::Neuter => "it's",
-            Self::Trans => "they're",
+            Self::NonBinaryThey => "they're",
         }
     }
 
@@ -60,7 +60,7 @@ impl Gender {
             Self::Feminine => "She's",
             Self::Masculine => "He's",
             Self::Neuter => "It's",
-            Self::Trans => "They're",
+            Self::NonBinaryThey => "They're",
         }
     }
 
@@ -69,7 +69,7 @@ impl Gender {
             Self::Feminine => "she's",
             Self::Masculine => "he's",
             Self::Neuter => "it's",
-            Self::Trans => "they've",
+            Self::NonBinaryThey => "they've",
         }
     }
 
@@ -78,7 +78,7 @@ impl Gender {
             Self::Feminine => "She's",
             Self::Masculine => "He's",
             Self::Neuter => "It's",
-            Self::Trans => "They've",
+            Self::NonBinaryThey => "They've",
         }
     }
 
@@ -87,7 +87,7 @@ impl Gender {
             Self::Feminine => "her",
             Self::Masculine => "him",
             Self::Neuter => "it",
-            Self::Trans => "them",
+            Self::NonBinaryThey => "them",
         }
     }
 
@@ -96,7 +96,7 @@ impl Gender {
             Self::Feminine => "Her",
             Self::Masculine => "Him",
             Self::Neuter => "It",
-            Self::Trans => "Them",
+            Self::NonBinaryThey => "Them",
         }
     }
 
@@ -105,7 +105,7 @@ impl Gender {
             Self::Feminine => "her",
             Self::Masculine => "his",
             Self::Neuter => "its",
-            Self::Trans => "their",
+            Self::NonBinaryThey => "their",
         }
     }
 
@@ -114,7 +114,7 @@ impl Gender {
             Self::Feminine => "Her",
             Self::Masculine => "His",
             Self::Neuter => "Its",
-            Self::Trans => "Their",
+            Self::NonBinaryThey => "Their",
         }
     }
 
@@ -123,7 +123,7 @@ impl Gender {
             Self::Feminine => "hers",
             Self::Masculine => "his",
             Self::Neuter => "its",
-            Self::Trans => "theirs",
+            Self::NonBinaryThey => "theirs",
         }
     }
 
@@ -132,7 +132,7 @@ impl Gender {
             Self::Feminine => "Hers",
             Self::Masculine => "His",
             Self::Neuter => "Its",
-            Self::Trans => "Theirs",
+            Self::NonBinaryThey => "Theirs",
         }
     }
 
@@ -141,7 +141,7 @@ impl Gender {
             Self::Feminine => "herself",
             Self::Masculine => "himself",
             Self::Neuter => "itself",
-            Self::Trans => "themself",
+            Self::NonBinaryThey => "themself",
         }
     }
 
@@ -150,12 +150,12 @@ impl Gender {
             Self::Feminine => "Herself",
             Self::Masculine => "Himself",
             Self::Neuter => "Itself",
-            Self::Trans => "Themself",
+            Self::NonBinaryThey => "Themself",
         }
     }
 
     pub fn conjugate<'a>(&self, singular_form: &'a str, plural_form: &'a str) -> &'a str {
-        if self == &Self::Trans {
+        if self == &Self::NonBinaryThey {
             plural_form
         } else {
             singular_form
@@ -168,7 +168,7 @@ impl fmt::Display for Gender {
         match self {
             Self::Masculine => write!(f, "masculine (he/him)"),
             Self::Feminine => write!(f, "feminine (she/her)"),
-            Self::Trans => write!(f, "trans (they/them)"),
+            Self::NonBinaryThey => write!(f, "non-binary (they/them)"),
             Self::Neuter => write!(f, "neuter (it)"),
         }
     }
@@ -265,7 +265,10 @@ mod test {
     fn fmt_test() {
         assert_eq!("masculine (he/him)", format!("{}", Gender::Masculine));
         assert_eq!("feminine (she/her)", format!("{}", Gender::Feminine));
-        assert_eq!("trans (they/them)", format!("{}", Gender::Trans));
+        assert_eq!(
+            "non-binary (they/them)",
+            format!("{}", Gender::NonBinaryThey)
+        );
         assert_eq!("neuter (it)", format!("{}", Gender::Neuter));
     }
 
@@ -276,7 +279,7 @@ mod test {
         assert_eq!("\"Feminine\"", serde_json::to_string(&f).unwrap());
         assert_eq!("\"Masculine\"", serde_json::to_string(&m).unwrap());
         assert_eq!("\"Neuter\"", serde_json::to_string(&n).unwrap());
-        assert_eq!("\"Trans\"", serde_json::to_string(&t).unwrap());
+        assert_eq!("\"NonBinaryThey\"", serde_json::to_string(&t).unwrap());
 
         let value: Gender = serde_json::from_str("\"Feminine\"").unwrap();
         assert_eq!(f, value);
@@ -287,7 +290,7 @@ mod test {
         let value: Gender = serde_json::from_str("\"Neuter\"").unwrap();
         assert_eq!(n, value);
 
-        let value: Gender = serde_json::from_str("\"Trans\"").unwrap();
+        let value: Gender = serde_json::from_str("\"NonBinaryThey\"").unwrap();
         assert_eq!(t, value);
     }
 
@@ -296,7 +299,7 @@ mod test {
             Gender::Feminine,
             Gender::Masculine,
             Gender::Neuter,
-            Gender::Trans,
+            Gender::NonBinaryThey,
         ]
     }
 }

--- a/core/src/world/npc/mod.rs
+++ b/core/src/world/npc/mod.rs
@@ -53,7 +53,10 @@ impl Npc {
     }
 
     pub fn gender(&self) -> Gender {
-        self.gender.value().copied().unwrap_or(Gender::Trans)
+        self.gender
+            .value()
+            .copied()
+            .unwrap_or(Gender::NonBinaryThey)
     }
 }
 
@@ -89,7 +92,7 @@ mod test {
     #[test]
     fn gender_test() {
         let mut npc = Npc::default();
-        assert_eq!(Gender::Trans, npc.gender());
+        assert_eq!(Gender::NonBinaryThey, npc.gender());
 
         npc.gender.replace(Gender::Feminine);
         assert_eq!(Gender::Feminine, npc.gender());

--- a/core/src/world/npc/species/dragonborn.rs
+++ b/core/src/world/npc/species/dragonborn.rs
@@ -8,7 +8,7 @@ impl Generate for Species {
         match rng.gen_range(1..=101) {
             1..=50 => Gender::Feminine,
             51..=100 => Gender::Masculine,
-            101 => Gender::Trans,
+            101 => Gender::NonBinaryThey,
             _ => unreachable!(),
         }
     }
@@ -50,7 +50,7 @@ mod test_generate_for_species {
         }
 
         assert_eq!(3, genders.len());
-        assert_eq!(Some(&3), genders.get("trans (they/them)"));
+        assert_eq!(Some(&3), genders.get("non-binary (they/them)"));
         assert_eq!(Some(&233), genders.get("feminine (she/her)"));
         assert_eq!(Some(&264), genders.get("masculine (he/him)"));
     }
@@ -81,7 +81,7 @@ mod test_generate_for_species {
     fn gen_size_test() {
         let mut rng = SmallRng::seed_from_u64(0);
         let age = Age::Adult(0);
-        let t = Gender::Trans;
+        let t = Gender::NonBinaryThey;
 
         let size = |height, weight| Size::Medium { height, weight };
 

--- a/core/src/world/npc/species/dwarf.rs
+++ b/core/src/world/npc/species/dwarf.rs
@@ -8,7 +8,7 @@ impl Generate for Species {
         match rng.gen_range(1..=101) {
             1..=50 => Gender::Feminine,
             51..=100 => Gender::Masculine,
-            101 => Gender::Trans,
+            101 => Gender::NonBinaryThey,
             _ => unreachable!(),
         }
     }
@@ -51,7 +51,7 @@ mod test_generate_for_species {
         }
 
         assert_eq!(3, genders.len());
-        assert_eq!(Some(&3), genders.get("trans (they/them)"));
+        assert_eq!(Some(&3), genders.get("non-binary (they/them)"));
         assert_eq!(Some(&233), genders.get("feminine (she/her)"));
         assert_eq!(Some(&264), genders.get("masculine (he/him)"));
     }
@@ -82,7 +82,7 @@ mod test_generate_for_species {
     fn gen_size_test() {
         let mut rng = SmallRng::seed_from_u64(0);
         let age = Age::Adult(0);
-        let t = Gender::Trans;
+        let t = Gender::NonBinaryThey;
 
         let size = |height, weight| Size::Medium { height, weight };
 

--- a/core/src/world/npc/species/elf.rs
+++ b/core/src/world/npc/species/elf.rs
@@ -8,7 +8,7 @@ impl Generate for Species {
         match rng.gen_range(1..=101) {
             1..=50 => Gender::Feminine,
             51..=100 => Gender::Masculine,
-            101 => Gender::Trans,
+            101 => Gender::NonBinaryThey,
             _ => unreachable!(),
         }
     }
@@ -51,7 +51,7 @@ mod test_generate_for_species {
         }
 
         assert_eq!(3, genders.len());
-        assert_eq!(Some(&3), genders.get("trans (they/them)"));
+        assert_eq!(Some(&3), genders.get("non-binary (they/them)"));
         assert_eq!(Some(&233), genders.get("feminine (she/her)"));
         assert_eq!(Some(&264), genders.get("masculine (he/him)"));
     }
@@ -82,7 +82,7 @@ mod test_generate_for_species {
     fn gen_size_test() {
         let mut rng = SmallRng::seed_from_u64(0);
         let age = Age::Adult(0);
-        let t = Gender::Trans;
+        let t = Gender::NonBinaryThey;
 
         let size = |height, weight| Size::Medium { height, weight };
 

--- a/core/src/world/npc/species/gnome.rs
+++ b/core/src/world/npc/species/gnome.rs
@@ -8,7 +8,7 @@ impl Generate for Species {
         match rng.gen_range(1..=101) {
             1..=50 => Gender::Feminine,
             51..=100 => Gender::Masculine,
-            101 => Gender::Trans,
+            101 => Gender::NonBinaryThey,
             _ => unreachable!(),
         }
     }
@@ -51,7 +51,7 @@ mod test_generate_for_species {
         }
 
         assert_eq!(3, genders.len());
-        assert_eq!(Some(&3), genders.get("trans (they/them)"));
+        assert_eq!(Some(&3), genders.get("non-binary (they/them)"));
         assert_eq!(Some(&233), genders.get("feminine (she/her)"));
         assert_eq!(Some(&264), genders.get("masculine (he/him)"));
     }
@@ -82,7 +82,7 @@ mod test_generate_for_species {
     fn gen_size_test() {
         let mut rng = SmallRng::seed_from_u64(0);
         let age = Age::Adult(0);
-        let t = Gender::Trans;
+        let t = Gender::NonBinaryThey;
 
         let size = |height, weight| Size::Small { height, weight };
 

--- a/core/src/world/npc/species/half_elf.rs
+++ b/core/src/world/npc/species/half_elf.rs
@@ -68,8 +68,8 @@ mod test_generate_for_species {
 
         for _ in 0..10 {
             assert_eq!(
-                Species::gen_size(&mut rng1, &Age::Adult(0), &Gender::Trans),
-                Human::gen_size(&mut rng2, &Age::Adult(0), &Gender::Trans),
+                Species::gen_size(&mut rng1, &Age::Adult(0), &Gender::NonBinaryThey),
+                Human::gen_size(&mut rng2, &Age::Adult(0), &Gender::NonBinaryThey),
             );
         }
     }

--- a/core/src/world/npc/species/half_orc.rs
+++ b/core/src/world/npc/species/half_orc.rs
@@ -8,7 +8,7 @@ impl Generate for Species {
         match rng.gen_range(1..=101) {
             1..=50 => Gender::Feminine,
             51..=100 => Gender::Masculine,
-            101 => Gender::Trans,
+            101 => Gender::NonBinaryThey,
             _ => unreachable!(),
         }
     }
@@ -51,7 +51,7 @@ mod test_generate_for_species {
         }
 
         assert_eq!(3, genders.len());
-        assert_eq!(Some(&3), genders.get("trans (they/them)"));
+        assert_eq!(Some(&3), genders.get("non-binary (they/them)"));
         assert_eq!(Some(&233), genders.get("feminine (she/her)"));
         assert_eq!(Some(&264), genders.get("masculine (he/him)"));
     }
@@ -82,7 +82,7 @@ mod test_generate_for_species {
     fn gen_size_test() {
         let mut rng = SmallRng::seed_from_u64(0);
         let age = Age::Adult(0);
-        let t = Gender::Trans;
+        let t = Gender::NonBinaryThey;
 
         let size = |height, weight| Size::Medium { height, weight };
 

--- a/core/src/world/npc/species/halfling.rs
+++ b/core/src/world/npc/species/halfling.rs
@@ -8,7 +8,7 @@ impl Generate for Species {
         match rng.gen_range(1..=101) {
             1..=50 => Gender::Feminine,
             51..=100 => Gender::Masculine,
-            101 => Gender::Trans,
+            101 => Gender::NonBinaryThey,
             _ => unreachable!(),
         }
     }
@@ -51,7 +51,7 @@ mod test_generate_for_species {
         }
 
         assert_eq!(3, genders.len());
-        assert_eq!(Some(&3), genders.get("trans (they/them)"));
+        assert_eq!(Some(&3), genders.get("non-binary (they/them)"));
         assert_eq!(Some(&233), genders.get("feminine (she/her)"));
         assert_eq!(Some(&264), genders.get("masculine (he/him)"));
     }
@@ -82,7 +82,7 @@ mod test_generate_for_species {
     fn gen_size_test() {
         let mut rng = SmallRng::seed_from_u64(0);
         let age = Age::Adult(0);
-        let t = Gender::Trans;
+        let t = Gender::NonBinaryThey;
 
         let size = |height, weight| Size::Small { height, weight };
 

--- a/core/src/world/npc/species/human.rs
+++ b/core/src/world/npc/species/human.rs
@@ -23,7 +23,7 @@ impl Generate for Species {
         match rng.gen_range(1..=101) {
             1..=50 => Gender::Feminine,
             51..=100 => Gender::Masculine,
-            101 => Gender::Trans,
+            101 => Gender::NonBinaryThey,
             _ => unreachable!(),
         }
     }
@@ -118,7 +118,7 @@ mod test_generate_for_species {
         }
 
         assert_eq!(3, genders.len());
-        assert_eq!(Some(&3), genders.get("trans (they/them)"));
+        assert_eq!(Some(&3), genders.get("non-binary (they/them)"));
         assert_eq!(Some(&233), genders.get("feminine (she/her)"));
         assert_eq!(Some(&264), genders.get("masculine (he/him)"));
     }

--- a/core/src/world/npc/species/tiefling.rs
+++ b/core/src/world/npc/species/tiefling.rs
@@ -68,8 +68,8 @@ mod test_generate_for_species {
 
         for _ in 0..10 {
             assert_eq!(
-                Species::gen_size(&mut rng1, &Age::Adult(0), &Gender::Trans),
-                Human::gen_size(&mut rng2, &Age::Adult(0), &Gender::Trans),
+                Species::gen_size(&mut rng1, &Age::Adult(0), &Gender::NonBinaryThey),
+                Human::gen_size(&mut rng2, &Age::Adult(0), &Gender::NonBinaryThey),
             );
         }
     }

--- a/core/src/world/npc/species/warforged.rs
+++ b/core/src/world/npc/species/warforged.rs
@@ -9,7 +9,7 @@ impl Generate for Species {
             1..=60 => Gender::Neuter,
             61..=75 => Gender::Masculine,
             76..=90 => Gender::Feminine,
-            91..=100 => Gender::Trans,
+            91..=100 => Gender::NonBinaryThey,
             _ => unreachable!(),
         }
     }
@@ -46,7 +46,7 @@ mod test_generate_for_species {
         assert_eq!(Some(&59), genders.get("neuter (it)"));
         assert_eq!(Some(&15), genders.get("feminine (she/her)"));
         assert_eq!(Some(&16), genders.get("masculine (he/him)"));
-        assert_eq!(Some(&10), genders.get("trans (they/them)"));
+        assert_eq!(Some(&10), genders.get("non-binary (they/them)"));
     }
 
     #[test]
@@ -75,7 +75,7 @@ mod test_generate_for_species {
     fn gen_size_test() {
         let mut rng = SmallRng::seed_from_u64(0);
         let age = Age::Adult(0);
-        let t = Gender::Trans;
+        let t = Gender::NonBinaryThey;
 
         let size = |height, weight| Size::Medium { height, weight };
 

--- a/core/src/world/npc/view.rs
+++ b/core/src/world/npc/view.rs
@@ -182,7 +182,7 @@ mod test_display_for_npc_details_view {
         npc.name.replace("Potato Johnson".to_string());
         npc.species.replace(Species::Human);
         npc.ethnicity.replace(Ethnicity::Elvish);
-        npc.gender.replace(Gender::Trans);
+        npc.gender.replace(Gender::NonBinaryThey);
         npc.age.replace(Age::Adult(30));
         npc.size.replace(Size::Medium {
             height: 71,
@@ -195,7 +195,7 @@ mod test_display_for_npc_details_view {
 *adult human, they/them*
 
 **Species:** human (Elvish)\\
-**Gender:** trans\\
+**Gender:** non-binary\\
 **Age:** 30 years\\
 **Size:** 5'11\", 140 lbs (medium)",
             format!("{}", npc.display_details())
@@ -250,7 +250,7 @@ mod test_display_for_npc_details_view {
             npc.species = Field::new_generated(Species::Human);
         }
         if bitmask & 0b1000 > 0 {
-            npc.gender = Field::new_generated(Gender::Trans);
+            npc.gender = Field::new_generated(Gender::NonBinaryThey);
         }
 
         npc

--- a/core/src/world/thing.rs
+++ b/core/src/world/thing.rs
@@ -293,7 +293,7 @@ mod test {
     fn gender_test() {
         assert_eq!(Gender::Neuter, location().gender());
         assert_eq!(Gender::Neuter, region().gender());
-        assert_eq!(Gender::Trans, npc().gender());
+        assert_eq!(Gender::NonBinaryThey, npc().gender());
 
         let npc = Thing::Npc(Npc {
             gender: Gender::Feminine.into(),

--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,3 +1,5 @@
+* **Enhancement:** Corrected terminology so that NPCs using "they/them" pronouns
+  will be referred to as "non-binary" rather than "trans".
 * **Enhancement:** The `tutorial` is now rather less brutal. Instead of killing
   the poor bartender, our hypothetical murderhobos just let the inn burn to the
   ground and delete that instead. (Spoilers, BTW.)

--- a/web/js/database.js
+++ b/web/js/database.js
@@ -2,9 +2,26 @@ import Dexie from "dexie"
 
 const dexie = new Dexie("initiative")
 
+dexie.version(3).stores({
+  things: "&uuid, name, type",
+  keyValue: "&key",
+}).upgrade((tx) => {
+  return tx.table("things").toCollection().modify((thing) => {
+    if (thing.type === "Npc") {
+      if (thing.gender == "Trans") {
+        thing.gender = "NonBinaryThey"
+      }
+    }
+  })
+})
+
 dexie.version(2).stores({
   things: "&uuid, name, type",
   keyValue: "&key",
+})
+
+dexie.version(1).stores({
+  things: "&uuid, name, type",
 })
 
 const delete_thing_by_uuid = async (uuid) => {


### PR DESCRIPTION
Rather than referring to they/them pronouns as "trans", change descriptor to "non-binary". Enum variant is named NonBinaryThey to keep the possibility of other non-binary pronouns in the future.

Resolves #168.