### PR TITLE
Fix selecting for copy

### DIFF
--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,3 +1,6 @@
+* **Bug:** Fix broken text selection, which was preventing copy/paste
+  operations. I wasn't trying to do the annoying "right click disabled" thing
+  from the early '00s, but it sure felt like it.
 * **New:** You can now edit things in your journal and recent items! Try
   `[name] is [description]` to get started.
 * **Enhancement:** The `redo` command is now available at all times, not just

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -195,11 +195,16 @@ window.addEventListener("keydown", (event) => {
   }
 })
 
-window.addEventListener("click", async (event) => {
-  if (event.target.nodeName === "CODE") {
-    await runCommand(event.target.innerText)
-  } else {
-    promptElement.focus()
+let mouseMoveEvents = 0
+window.addEventListener("mousedown", () => mouseMoveEvents = 0)
+window.addEventListener("mousemove", () => mouseMoveEvents++)
+window.addEventListener("mouseup", async (event) => {
+  if (mouseMoveEvents < 5) {
+    if (event.target.nodeName === "CODE") {
+      await runCommand(event.target.innerText)
+    } else {
+      promptElement.focus()
+    }
   }
 })
 


### PR DESCRIPTION
Fix an incidental bug where dragging the mouse would immediately deselect whatever text you were trying to select.