### PR TITLE
Only focus input field on single click

### DIFF
--- a/web/js/terminal.js
+++ b/web/js/terminal.js
@@ -182,7 +182,7 @@ function initialize(elementId, autocompleteCallback) {
   window.addEventListener("mousedown", () => mouseMoveEvents = 0)
   window.addEventListener("mousemove", () => mouseMoveEvents++)
   window.addEventListener("mouseup", async (event) => {
-    if (event.button == 0 && mouseMoveEvents < 5) {
+    if (event.button === 0 && mouseMoveEvents < 5 && event.detail === 1) {
       if (event.target.nodeName === "CODE") {
         await runCommand(event.target.innerText)
       } else {


### PR DESCRIPTION
Update logic for "sticky" input field to only focus on the input when clicking once. This makes it possible to double- or triple-click to select text without the selection being immediately broken by the frontend.

Resolves #239.