### PR TITLE
Fix unexpected tab key behaviour

### DIFF
--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,3 +1,5 @@
+* **Bug:** Fixed the tab key unexpectedly clearing the input field under certain
+  circumstances.
 * **Enhancement:** Added conditions such as `Prone` and `Stunned` to the
   reference corpus. There aren't a lot of them, but I keep having to look up
   their details anyway!

--- a/web/js/terminal.js
+++ b/web/js/terminal.js
@@ -272,7 +272,6 @@ function initialize(elementId, autocompleteCallback) {
 
   function tabEvent(event) {
     if (autoCompleteJS.cursor > -1) {
-      console.log(autoCompleteJS.feedback.results[autoCompleteJS.cursor].value.suggestion)
       selectBracketedExpression(
         autoCompleteJS.feedback.results[autoCompleteJS.cursor].value.suggestion
       )
@@ -280,10 +279,12 @@ function initialize(elementId, autocompleteCallback) {
       const commonPrefix = autoCompleteJS.feedback.results
         .map((result) => result.value.suggestion)
         .reduce((a, b) => {
-          let acc = ""
-          for (let i = 0; i < a.length && i < b.length; i++) {
+          let acc = promptElement.value
+          for (let i = promptElement.value.length; i < a.length && i < b.length; i++) {
             if (a[i] == b[i]) {
               acc += a[i]
+            } else if (a[i].toLowerCase() == b[i].toLowerCase()) {
+              acc += a[i].toLowerCase()
             } else {
               break
             }


### PR DESCRIPTION
Fix a bug wherein the tab key would clear the input field when there were multiple results with different capitalization, eg. "elderly" and "Eldrich Blast".

Resolves #232.