### PR TITLE
add fixed-position input

### DIFF
--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,3 +1,4 @@
+* **Enhancement:** The input box now scrolls with the page. @alfonsomartinezs
 * **Bug:** Update outdated references in the documentation about the app being
   case-sensitive, and a bit of expectation management around the project being
   in "active development".

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -25,7 +25,7 @@ body {
 }
 
 #output {
-    margin: 0.5rem 0.5rem 0;
+    margin: 0.5rem 0.5rem 3.5rem;
     padding: 0 0 1rem;
 }
 
@@ -199,11 +199,15 @@ body {
 }
 
 #prompt-form {
-    background: var(--solarized-scheme2);
+    background: linear-gradient(rgb(0,0,0,0),var(--solarized-scheme3),var(--solarized-scheme3));
     color: var(--solarized-scheme01);
-    margin: 1.4rem 0.5rem 0.5rem;
-    position: relative;
+    padding: 1.4rem 0.5rem 0.5rem;
+    position: fixed;
     white-space: nowrap;
+    bottom: 0;
+    width: 100%;
+    max-width: 100ch;
+    box-sizing: border-box;
 }
 
 #prompt-form::before {
@@ -211,7 +215,7 @@ body {
 }
 
 #prompt {
-    background: none;
+    background: var(--solarized-scheme2);
     border: none;
     color: var(--solarized-scheme02);
     font-weight: bold;

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -199,7 +199,7 @@ body {
 }
 
 #prompt-form {
-    background: linear-gradient(rgb(0,0,0,0),var(--solarized-scheme3),var(--solarized-scheme3));
+    background: linear-gradient(rgb(0,0,0,0), var(--solarized-scheme3) 1.0rem 100%);
     color: var(--solarized-scheme01);
     padding: 1.4rem 0.5rem 0.5rem;
     position: fixed;


### PR DESCRIPTION
updates styling for `.prompt-form` so that it "sticks" to the bottom of the page. Added a margin to the output so that it is never hidden by the input prompt and replaced the prompt-form margin with padding and added a gradient as a small preview to whatever's underneath the input.

didn't test with edge but it works with firefox/chrome and none of the newer attributes were used. Works for light and dark mode.