### PR TITLE
Update code standards & link GitHub profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ version = "0.1.0"
 dependencies = [
  "initiative-reference",
  "quote",
+ "regex",
  "syn",
 ]
 

--- a/core/src/storage/repository.rs
+++ b/core/src/storage/repository.rs
@@ -101,7 +101,7 @@ impl Repository {
         if self.data_store.health_check().await.is_ok() {
             self.data_store_enabled = true;
         } else {
-            self.data_store = Box::new(MemoryDataStore::default());
+            self.data_store = Box::<MemoryDataStore>::default();
         }
     }
 

--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,3 +1,5 @@
+* **Enhancement:** GitHub usernames in the changelog are now links, making it
+  easier to attribute work. @MikkelPaulson
 * **Enhancement:** The input box now scrolls with the page. @alfonsomartinezs
 * **Bug:** Update outdated references in the documentation about the app being
   case-sensitive, and a bit of expectation management around the project being

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -14,4 +14,5 @@ proc-macro = true
 [dependencies]
 initiative-reference = { path = "../reference" }
 quote = "1.0"
+regex = "1.7"
 syn = "1.0"

--- a/macros/src/changelog.rs
+++ b/macros/src/changelog.rs
@@ -1,4 +1,5 @@
 use proc_macro::{Literal, TokenStream, TokenTree};
+use std::borrow::Cow;
 
 pub fn run(input: TokenStream) -> Result<TokenStream, String> {
     if !input.is_empty() {
@@ -6,14 +7,22 @@ pub fn run(input: TokenStream) -> Result<TokenStream, String> {
     }
 
     let changelog = include_str!("../../data/changelog.md");
-    let token_tree: TokenTree = Literal::string(
-        changelog
-            .split_inclusive("\n*")
-            .take(10)
-            .collect::<String>()
-            .trim_end_matches(&['\n', '*'][..]),
-    )
-    .into();
 
-    Ok(token_tree.into())
+    let top_items = changelog
+        .split_inclusive("\n*")
+        .take(10)
+        .collect::<String>();
+
+    Ok(TokenTree::from(Literal::string(
+        linkify(&top_items).trim_end_matches(&['\n', '*'][..]),
+    ))
+    .into())
+}
+
+pub fn linkify(input: &str) -> Cow<str> {
+    let re = regex::Regex::new(r"@([\w]+)").unwrap();
+    re.replace_all(
+        input,
+        "<a href=\"https://github.com/$1\" target=\"_blank\">@$1</a>",
+    )
 }

--- a/macros/src/motd.rs
+++ b/macros/src/motd.rs
@@ -1,3 +1,4 @@
+use super::changelog::linkify;
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::LitStr;
@@ -16,12 +17,14 @@ Latest `changelog` entry:
 
 {}",
         base_motd.trim_end(),
-        changelog
-            .lines()
-            .enumerate()
-            .take_while(|&(i, s)| i == 0 || !s.starts_with('*'))
-            .map(|(_, s)| s)
-            .collect::<String>()
+        linkify(
+            &changelog
+                .lines()
+                .enumerate()
+                .take_while(|&(i, s)| i == 0 || !s.starts_with('*'))
+                .map(|(_, s)| s)
+                .collect::<String>()
+        )
     );
 
     let motd_len = motd.len();


### PR DESCRIPTION
* Update coding standards to conform to latest Clippy lints.
* Add links to GitHub profile references in changelog.