### PR TITLE
Fix clippy errors encountered in GH Actions for Rust 1.70.0

### DIFF
--- a/core/src/world/demographics.rs
+++ b/core/src/world/demographics.rs
@@ -71,7 +71,7 @@ impl Demographics {
         } else {
             let (groups, weights): (Vec<(Species, Ethnicity)>, Vec<u64>) =
                 self.groups().iter().unzip();
-            let dist = WeightedIndex::new(&weights).unwrap();
+            let dist = WeightedIndex::new(weights).unwrap();
             groups[dist.sample(rng)]
         }
     }

--- a/core/src/world/thing.rs
+++ b/core/src/world/thing.rs
@@ -17,7 +17,9 @@ pub enum Thing {
 }
 
 #[derive(Debug)]
+#[derive(Default)]
 pub enum ThingRelations {
+    #[default]
     None,
     Npc(NpcRelations),
     Place(PlaceRelations),
@@ -165,11 +167,7 @@ impl From<Place> for Thing {
     }
 }
 
-impl Default for ThingRelations {
-    fn default() -> Self {
-        ThingRelations::None
-    }
-}
+
 
 impl From<NpcRelations> for ThingRelations {
     fn from(input: NpcRelations) -> Self {

--- a/core/src/world/thing.rs
+++ b/core/src/world/thing.rs
@@ -16,8 +16,7 @@ pub enum Thing {
     Place(Place),
 }
 
-#[derive(Debug)]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub enum ThingRelations {
     #[default]
     None,
@@ -166,8 +165,6 @@ impl From<Place> for Thing {
         Thing::Place(place)
     }
 }
-
-
 
 impl From<NpcRelations> for ThingRelations {
     fn from(input: NpcRelations) -> Self {

--- a/core/src/world/word.rs
+++ b/core/src/world/word.rs
@@ -109,7 +109,7 @@ pub fn symbol(rng: &mut impl Rng) -> &'static str {
 }
 
 pub fn animal(rng: &mut impl Rng) -> &'static str {
-    let dist = WeightedIndex::new(&[LAND_ANIMALS.len(), COASTAL_ANIMALS.len()]).unwrap();
+    let dist = WeightedIndex::new([LAND_ANIMALS.len(), COASTAL_ANIMALS.len()]).unwrap();
     match dist.sample(rng) {
         0 => land_animal(rng),
         1 => coastal_animal(rng),


### PR DESCRIPTION
Used `cargo clippy --fix --lib -p initiative-core` to fix #314 

This then caused `rustfmt` to be unhappy, so I fixed that too.