### PR TITLE
Clippy: "use of `default` to create a unit struct"

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let data_store = core::NullDataStore::default();
+    let data_store = core::NullDataStore;
     cli::run(core::app(data_store, &event_dispatcher)).await?;
     Ok(())
 }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -75,7 +75,7 @@ static mut ROOT_ELEMENT_ID: Option<String> = None;
 fn app() -> &'static mut core::app::App {
     unsafe {
         if APP.is_none() {
-            let data_store = DataStore::default();
+            let data_store = DataStore;
             APP = Some(core::app(data_store, &event_dispatcher));
         }
 


### PR DESCRIPTION
Fix a very particular Clippy lint.