### PR TITLE
Add flag to resolve Cloudflare build issue

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ fi
 cd "$project_root/web"
 wasm-pack build --release
 npm install
-npm run build
+NODE_OPTIONS=--openssl-legacy-provider npm run build
 
 
 cd "$project_root"


### PR DESCRIPTION
Build was failing due to a version compatibility mismatch between the version of Node running on Cloudflare's build environment and something something software being built. Added the --openssl-legacy-provider flag per the following:

https://stackoverflow.com/questions/75959563/node-js-err-ossl-evp-unsupported-error-when-running-npm-run-start

Resolves #319.