### PR TITLE
Update ContextAwareParse to return CommandMatches

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -33,7 +33,7 @@ jobs:
           `changelog` command, and broadcast to Discord upon release.
 
           This reminder can be ignored for changes with no user-facing impact, such as
-          dependency updates and refactors. Or not! It's up to you, really.' >&2
+          dependency updates and refactors. Or not! It'"'"'s up to you, really.' >&2
 
             exit 1
           fi

--- a/core/src/app/command/app.rs
+++ b/core/src/app/command/app.rs
@@ -195,13 +195,13 @@ mod test {
     fn display_test() {
         let app_meta = app_meta();
 
-        vec![
+        [
             AppCommand::About,
             AppCommand::Changelog,
             AppCommand::Debug,
             AppCommand::Help,
         ]
-        .drain(..)
+        .into_iter()
         .for_each(|command| {
             let command_string = command.to_string();
             assert_ne!("", command_string);

--- a/core/src/app/command/mod.rs
+++ b/core/src/app/command/mod.rs
@@ -95,7 +95,7 @@ impl Runnable for Command {
                     .map(|command| format!("\n* `{}`", command))
                     .collect();
                 lines.sort();
-                lines.drain(..).for_each(|line| message.push_str(&line));
+                lines.into_iter().for_each(|line| message.push_str(&line));
                 Some(message)
             } else {
                 None
@@ -159,7 +159,7 @@ impl Autocomplete for Command {
         input: &str,
         app_meta: &AppMeta,
     ) -> Vec<(Cow<'static, str>, Cow<'static, str>)> {
-        let mut results = join!(
+        let results = join!(
             CommandAlias::autocomplete(input, app_meta),
             AppCommand::autocomplete(input, app_meta),
             ReferenceCommand::autocomplete(input, app_meta),
@@ -170,13 +170,13 @@ impl Autocomplete for Command {
         );
 
         std::iter::empty()
-            .chain(results.0.drain(..))
-            .chain(results.1.drain(..))
-            .chain(results.2.drain(..))
-            .chain(results.3.drain(..))
-            .chain(results.4.drain(..))
-            .chain(results.5.drain(..))
-            .chain(results.6.drain(..))
+            .chain(results.0)
+            .chain(results.1)
+            .chain(results.2)
+            .chain(results.3)
+            .chain(results.4)
+            .chain(results.5)
+            .chain(results.6)
             .collect()
     }
 }

--- a/core/src/app/command/runnable.rs
+++ b/core/src/app/command/runnable.rs
@@ -9,7 +9,7 @@ pub trait Runnable: Sized {
 
 #[async_trait(?Send)]
 pub trait ContextAwareParse: Sized {
-    async fn parse_input(input: &str, app_meta: &AppMeta) -> (Option<Self>, Vec<Self>);
+    async fn parse_input(input: &str, app_meta: &AppMeta) -> CommandMatches<Self>;
 }
 
 #[async_trait(?Send)]
@@ -35,4 +35,275 @@ pub fn assert_autocomplete(
     actual.sort();
 
     assert_eq!(expected, actual);
+}
+
+/// Represents all possible parse results for a given input.
+///
+/// One of the key usability features (and major headaches) of initiative.sh is its use of fuzzy
+/// command matching. Most parsers assume only one possible valid interpretation, but initiative.sh
+/// has the concept of *canonical* and *fuzzy* matches.
+///
+/// **Canonical matches** are inputs that cannot possibly conflict with one another. This is
+/// achieved using differing prefixes, eg. all SRD reference lookups are prefixed as "srd item
+/// shield" (or "srd spell shield").
+///
+/// **Fuzzy matches** are commands that the user could possibly have meant with a given input. The
+/// reason we need to be particularly careful with fuzzy matches is because the user can add
+/// arbitrary names to their journal, and typing that arbitrary name is *usually* enough to pull it
+/// up again. However, that arbitrary name could easily be another command, which the user may not
+/// want to overwrite. (The notable built-in conflict is the example above, where "shield" is both
+/// an item and a spell.)
+///
+/// || Canonical matches || Fuzzy matches || Result ||
+/// | 0 | 0 | Error: "Unknown command: '...'" |
+/// | 0 | 1 | The fuzzy match is run. |
+/// | 0 | 2+ | Error: "There are several possible interpretations of this command. Did you mean:" |
+/// | 1 | 0 | The canonical match is run. |
+/// | 1 | 1+ | The canonical match is run, suffixed with the error: "There are other possible interpretations of this command. Did you mean:" |
+///
+/// Since the parsing logic in the code base runs several layers deep across a number of different
+/// structs, this struct provides utilities for combining multiple CommandMatches instances of
+/// differing types, and for transforming the inner type as needed.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommandMatches<T> {
+    pub canonical_match: Option<T>,
+    pub fuzzy_matches: Vec<T>,
+}
+
+impl<T: std::fmt::Debug> CommandMatches<T> {
+    /// Create a new instance of CommandMatches with a canonical match.
+    pub fn new_canonical(canonical_match: T) -> Self {
+        CommandMatches {
+            canonical_match: Some(canonical_match),
+            fuzzy_matches: Vec::new(),
+        }
+    }
+
+    /// Create a new instance of `CommandMatches` with a single fuzzy match.
+    pub fn new_fuzzy(fuzzy_match: T) -> Self {
+        CommandMatches {
+            canonical_match: None,
+            fuzzy_matches: vec![fuzzy_match],
+        }
+    }
+
+    /// Push a new canonical match. Panics if a canonical match is already present.
+    pub fn push_canonical(&mut self, canonical_match: T) {
+        if let Some(old_canonical_match) = &self.canonical_match {
+            panic!(
+                "trying to overwrite existing canonical match {:?} with new match {:?}",
+                old_canonical_match, canonical_match,
+            );
+        }
+
+        self.canonical_match = Some(canonical_match);
+    }
+
+    /// Add a new fuzzy match to the list of possibilities.
+    pub fn push_fuzzy(&mut self, fuzzy_match: T) {
+        self.fuzzy_matches.push(fuzzy_match);
+    }
+
+    /// Combine the current CommandMatches with another object that can be massaged into the same
+    /// type. The Vecs of fuzzy matches are combined. Panics if both objects lay claim to a
+    /// canonical match.
+    pub fn union<O>(mut self, other: CommandMatches<O>) -> Self
+    where
+        O: std::fmt::Debug,
+        T: From<O>,
+    {
+        let CommandMatches {
+            canonical_match,
+            fuzzy_matches,
+        } = other.into_subtype::<T>();
+
+        if let Some(canonical_match) = canonical_match {
+            self.push_canonical(canonical_match);
+        }
+
+        self.fuzzy_matches.reserve(fuzzy_matches.len());
+        fuzzy_matches
+            .into_iter()
+            .for_each(|fuzzy_match| self.push_fuzzy(fuzzy_match));
+
+        self
+    }
+
+    /// Variant of union() that resolves canonical conflicts by overwriting self.canonical_match
+    /// with other.canonical_match instead of panicking.
+    pub fn union_with_overwrite<O>(mut self, other: CommandMatches<O>) -> Self
+    where
+        O: std::fmt::Debug,
+        T: From<O>,
+    {
+        let self_canonical_match = self.canonical_match.take();
+
+        let mut result = self.union(other);
+
+        if result.canonical_match.is_none() {
+            result.canonical_match = self_canonical_match;
+        }
+
+        result
+    }
+
+    /// Convert a `CommandMatches<T>' into a `CommandMatches<O>`, massaging the inner type using
+    /// its `From<T>` trait.
+    ///
+    /// This could be an impl of `From<CommandMatches<T>> for CommandMatches<O>`, but that produces
+    /// a trait conflict due to limitations of Rust's type system.
+    pub fn into_subtype<O>(self) -> CommandMatches<O>
+    where
+        O: From<T> + std::fmt::Debug,
+    {
+        CommandMatches {
+            canonical_match: self
+                .canonical_match
+                .map(|canonical_match| canonical_match.into()),
+            fuzzy_matches: self
+                .fuzzy_matches
+                .into_iter()
+                .map(|fuzzy_match| fuzzy_match.into())
+                .collect(),
+        }
+    }
+
+    /// Consumes the struct, returning the following in priority order:
+    ///
+    /// 1. The canonical match, if present.
+    /// 2. The first fuzzy match, if any are present.
+    /// 3. `None`
+    pub fn take_best_match(self) -> Option<T> {
+        self.canonical_match
+            .or_else(|| self.fuzzy_matches.into_iter().next())
+    }
+}
+
+impl<T> From<T> for CommandMatches<T> {
+    fn from(input: T) -> Self {
+        CommandMatches {
+            canonical_match: Some(input),
+            fuzzy_matches: Vec::default(),
+        }
+    }
+}
+
+impl<T> Default for CommandMatches<T> {
+    fn default() -> Self {
+        CommandMatches {
+            canonical_match: None,
+            fuzzy_matches: Vec::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn command_matches_new_test() {
+        {
+            let command_matches = CommandMatches::new_canonical(true);
+            assert_eq!(Some(true), command_matches.canonical_match);
+            assert!(command_matches.fuzzy_matches.is_empty());
+        }
+
+        {
+            let command_matches = CommandMatches::new_fuzzy(true);
+            assert_eq!(Option::<bool>::None, command_matches.canonical_match);
+            assert_eq!([true][..], command_matches.fuzzy_matches[..]);
+        }
+
+        {
+            let command_matches = CommandMatches::default();
+            assert_eq!(Option::<bool>::None, command_matches.canonical_match);
+            assert!(command_matches.fuzzy_matches.is_empty());
+        }
+    }
+
+    #[test]
+    fn command_matches_push_test() {
+        {
+            let mut command_matches = CommandMatches::default();
+            command_matches.push_canonical(true);
+            assert_eq!(Some(true), command_matches.canonical_match);
+            assert!(command_matches.fuzzy_matches.is_empty());
+        }
+
+        {
+            let mut command_matches = CommandMatches::default();
+            command_matches.push_fuzzy(1u8);
+            command_matches.push_fuzzy(2);
+            assert_eq!(Option::<u8>::None, command_matches.canonical_match);
+            assert_eq!([1u8, 2][..], command_matches.fuzzy_matches[..]);
+        }
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "trying to overwrite existing canonical match true with new match false"
+    )]
+    fn command_matches_push_test_with_conflict() {
+        let mut command_matches = CommandMatches::default();
+        command_matches.push_canonical(true);
+        command_matches.push_canonical(false);
+    }
+
+    #[test]
+    fn command_matches_union_test() {
+        let command_matches_1 = {
+            let mut command_matches = CommandMatches::new_canonical(1u16);
+            command_matches.push_fuzzy(2);
+            command_matches.push_fuzzy(3);
+            command_matches
+        };
+        let command_matches_2 = CommandMatches::new_fuzzy(4u8);
+
+        let command_matches_result = command_matches_1.union(command_matches_2);
+
+        assert_eq!(Some(1u16), command_matches_result.canonical_match);
+        assert_eq!([2u16, 3, 4][..], command_matches_result.fuzzy_matches[..]);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "trying to overwrite existing canonical match true with new match false"
+    )]
+    fn command_matches_union_test_with_conflict() {
+        CommandMatches::new_canonical(true).union(CommandMatches::new_canonical(false));
+    }
+
+    #[test]
+    fn command_matches_union_with_overwrite_test() {
+        assert_eq!(
+            Some(2u16),
+            CommandMatches::new_canonical(1u16)
+                .union_with_overwrite(CommandMatches::new_canonical(2u8))
+                .canonical_match,
+        );
+    }
+
+    #[test]
+    fn command_matches_take_best_match_test() {
+        assert_eq!(
+            Some(true),
+            CommandMatches::new_canonical(true).take_best_match(),
+        );
+        assert_eq!(
+            Some(true),
+            CommandMatches::new_fuzzy(true).take_best_match(),
+        );
+
+        {
+            let mut command_matches = CommandMatches::new_canonical(true);
+            command_matches.push_fuzzy(false);
+            assert_eq!(Some(true), command_matches.take_best_match());
+        }
+
+        assert_eq!(
+            Option::<bool>::None,
+            CommandMatches::<bool>::default().take_best_match(),
+        );
+    }
 }

--- a/core/src/app/command/tutorial.rs
+++ b/core/src/app/command/tutorial.rs
@@ -1,6 +1,7 @@
 use super::CommandType;
 use crate::app::{
-    AppCommand, AppMeta, Autocomplete, Command, CommandAlias, ContextAwareParse, Runnable,
+    AppCommand, AppMeta, Autocomplete, Command, CommandAlias, CommandMatches, ContextAwareParse,
+    Runnable,
 };
 use crate::reference::{ItemCategory, ReferenceCommand, Spell};
 use crate::storage::{Change, StorageCommand};
@@ -743,15 +744,12 @@ impl Runnable for TutorialCommand {
 
 #[async_trait(?Send)]
 impl ContextAwareParse for TutorialCommand {
-    async fn parse_input(input: &str, _app_meta: &AppMeta) -> (Option<Self>, Vec<Self>) {
-        (
-            if input.eq_ci("tutorial") {
-                Some(TutorialCommand::Introduction)
-            } else {
-                None
-            },
-            Vec::new(),
-        )
+    async fn parse_input(input: &str, _app_meta: &AppMeta) -> CommandMatches<Self> {
+        if input.eq_ci("tutorial") {
+            CommandMatches::new_canonical(TutorialCommand::Introduction)
+        } else {
+            CommandMatches::default()
+        }
     }
 }
 

--- a/core/src/app/mod.rs
+++ b/core/src/app/mod.rs
@@ -1,4 +1,6 @@
-pub use command::{AppCommand, Autocomplete, Command, CommandAlias, ContextAwareParse, Runnable};
+pub use command::{
+    AppCommand, Autocomplete, Command, CommandAlias, CommandMatches, ContextAwareParse, Runnable,
+};
 pub use meta::AppMeta;
 
 #[cfg(test)]

--- a/core/src/reference/command.rs
+++ b/core/src/reference/command.rs
@@ -221,7 +221,7 @@ mod test {
     fn display_test() {
         let app_meta = app_meta();
 
-        vec![
+        [
             ReferenceCommand::Spell(Spell::Shield),
             ReferenceCommand::Spells,
             ReferenceCommand::Item(Item::Shield),
@@ -229,7 +229,7 @@ mod test {
             ReferenceCommand::MagicItem(MagicItem::DeckOfManyThings),
             ReferenceCommand::OpenGameLicense,
         ]
-        .drain(..)
+        .into_iter()
         .for_each(|command| {
             let command_string = command.to_string();
             assert_ne!("", command_string);

--- a/core/src/reference/command.rs
+++ b/core/src/reference/command.rs
@@ -1,5 +1,5 @@
 use super::{Condition, Item, ItemCategory, MagicItem, Spell, Trait};
-use crate::app::{AppMeta, Autocomplete, ContextAwareParse, Runnable};
+use crate::app::{AppMeta, Autocomplete, CommandMatches, ContextAwareParse, Runnable};
 use crate::utils::CaseInsensitiveStr;
 use async_trait::async_trait;
 use caith::Roller;
@@ -47,75 +47,68 @@ impl Runnable for ReferenceCommand {
 
 #[async_trait(?Send)]
 impl ContextAwareParse for ReferenceCommand {
-    async fn parse_input(input: &str, _app_meta: &AppMeta) -> (Option<Self>, Vec<Self>) {
-        let exact_match = if input.eq_ci("Open Game License") {
-            Some(Self::OpenGameLicense)
+    async fn parse_input(input: &str, _app_meta: &AppMeta) -> CommandMatches<Self> {
+        let mut matches = if input.eq_ci("Open Game License") {
+            CommandMatches::new_canonical(Self::OpenGameLicense)
         } else if input.eq_ci("srd spells") {
-            Some(Self::Spells)
+            CommandMatches::new_canonical(Self::Spells)
+        } else if let Some(condition) = input
+            .strip_prefix_ci("srd condition ")
+            .and_then(|s| s.parse().ok())
+        {
+            CommandMatches::new_canonical(Self::Condition(condition))
+        } else if let Some(item_category) = input
+            .strip_prefix_ci("srd item category ")
+            .and_then(|s| s.parse().ok())
+        {
+            CommandMatches::new_canonical(Self::ItemCategory(item_category))
+        } else if let Some(item) = input
+            .strip_prefix_ci("srd item ")
+            .and_then(|s| s.parse().ok())
+        {
+            CommandMatches::new_canonical(Self::Item(item))
+        } else if let Some(magic_item) = input
+            .strip_prefix_ci("srd magic item ")
+            .and_then(|s| s.parse().ok())
+        {
+            CommandMatches::new_canonical(Self::MagicItem(magic_item))
+        } else if let Some(spell) = input
+            .strip_prefix_ci("srd spell ")
+            .and_then(|s| s.parse().ok())
+        {
+            CommandMatches::new_canonical(Self::Spell(spell))
+        } else if let Some(character_trait) = input
+            .strip_prefix_ci("srd trait ")
+            .and_then(|s| s.parse().ok())
+        {
+            CommandMatches::new_canonical(Self::Trait(character_trait))
         } else {
-            None.or_else(|| {
-                input
-                    .strip_prefix_ci("srd condition ")
-                    .and_then(|s| s.parse().ok())
-                    .map(Self::Condition)
-            })
-            .or_else(|| {
-                input
-                    .strip_prefix_ci("srd item ")
-                    .and_then(|s| s.parse().ok())
-                    .map(Self::Item)
-            })
-            .or_else(|| {
-                input
-                    .strip_prefix_ci("srd item category ")
-                    .and_then(|s| s.parse().ok())
-                    .map(Self::ItemCategory)
-            })
-            .or_else(|| {
-                input
-                    .strip_prefix_ci("srd magic item ")
-                    .and_then(|s| s.parse().ok())
-                    .map(Self::MagicItem)
-            })
-            .or_else(|| {
-                input
-                    .strip_prefix_ci("srd spell ")
-                    .and_then(|s| s.parse().ok())
-                    .map(Self::Spell)
-            })
-            .or_else(|| {
-                input
-                    .strip_prefix_ci("srd trait ")
-                    .and_then(|s| s.parse().ok())
-                    .map(Self::Trait)
-            })
+            CommandMatches::default()
         };
 
-        let mut fuzzy_matches = Vec::new();
-
         if let Ok(condition) = input.parse() {
-            fuzzy_matches.push(Self::Condition(condition));
+            matches.push_fuzzy(Self::Condition(condition));
         }
         if let Ok(item) = input.parse() {
-            fuzzy_matches.push(Self::Item(item));
+            matches.push_fuzzy(Self::Item(item));
         }
         if let Ok(category) = input.parse() {
-            fuzzy_matches.push(Self::ItemCategory(category));
+            matches.push_fuzzy(Self::ItemCategory(category));
         }
         if let Ok(magic_item) = input.parse() {
-            fuzzy_matches.push(Self::MagicItem(magic_item));
+            matches.push_fuzzy(Self::MagicItem(magic_item));
         }
         if let Ok(spell) = input.parse() {
-            fuzzy_matches.push(Self::Spell(spell));
+            matches.push_fuzzy(Self::Spell(spell));
         }
-        if let Ok(t) = input.parse() {
-            fuzzy_matches.push(Self::Trait(t));
+        if let Ok(character_trait) = input.parse() {
+            matches.push_fuzzy(Self::Trait(character_trait));
         }
-        if input == "spells" {
-            fuzzy_matches.push(Self::Spells);
+        if input.eq_ci("spells") {
+            matches.push_fuzzy(Self::Spells);
         }
 
-        (exact_match, fuzzy_matches)
+        matches
     }
 }
 
@@ -242,14 +235,14 @@ mod test {
             assert_ne!("", command_string);
 
             assert_eq!(
-                (Some(command.clone()), Vec::new()),
+                CommandMatches::new_canonical(command.clone()),
                 block_on(ReferenceCommand::parse_input(&command_string, &app_meta)),
                 "{}",
                 command_string,
             );
 
             assert_eq!(
-                (Some(command), Vec::new()),
+                CommandMatches::new_canonical(command),
                 block_on(ReferenceCommand::parse_input(
                     &command_string.to_uppercase(),
                     &app_meta,

--- a/core/src/storage/backup.rs
+++ b/core/src/storage/backup.rs
@@ -52,7 +52,7 @@ pub async fn import(
 ) -> Result<ImportStats, RepositoryError> {
     let mut stats = ImportStats::default();
 
-    for thing in data.things.drain(..) {
+    for thing in data.things.into_iter() {
         match (
             match thing {
                 Thing::Npc(_) => &mut stats.npc_stats,

--- a/core/src/storage/command.rs
+++ b/core/src/storage/command.rs
@@ -37,7 +37,7 @@ impl Runnable for StorageCommand {
                     .journal()
                     .await
                     .map_err(|_| "Couldn't access the journal.".to_string())?
-                    .drain(..)
+                    .into_iter()
                     .map(|thing| match thing {
                         Thing::Npc(_) => npcs.push(thing),
                         Thing::Place(_) => places.push(thing),
@@ -58,7 +58,7 @@ impl Runnable for StorageCommand {
                             }
                         });
 
-                        things.drain(..).enumerate().for_each(|(i, thing)| {
+                        things.into_iter().enumerate().for_each(|(i, thing)| {
                             if i > 0 {
                                 output.push('\\');
                             }
@@ -673,7 +673,7 @@ mod test {
     fn display_test() {
         let app_meta = app_meta();
 
-        vec![
+        [
             StorageCommand::Delete {
                 name: "Potato Johnson".to_string(),
             },
@@ -687,7 +687,7 @@ mod test {
                 name: "Potato Johnson".to_string(),
             },
         ]
-        .drain(..)
+        .into_iter()
         .for_each(|command| {
             let command_string = command.to_string();
             assert_ne!("", command_string);

--- a/core/src/time/command.rs
+++ b/core/src/time/command.rs
@@ -310,7 +310,7 @@ mod test {
     fn display_test() {
         let app_meta = app_meta();
 
-        vec![
+        [
             TimeCommand::Add {
                 interval: Interval::new(2, 3, 4, 5, 6),
             },
@@ -319,7 +319,7 @@ mod test {
                 interval: Interval::new(2, 3, 4, 5, 6),
             },
         ]
-        .drain(..)
+        .into_iter()
         .for_each(|command| {
             let command_string = command.to_string();
             assert_ne!("", command_string);

--- a/core/src/world/command/mod.rs
+++ b/core/src/world/command/mod.rs
@@ -325,7 +325,7 @@ impl Autocomplete for WorldCommand {
             {
                 let split_pos = input.len() - input[is_word.range().end..].trim_start().len();
 
-                let mut edit_suggestions = match thing {
+                let edit_suggestions = match thing {
                     Thing::Npc(_) => Npc::autocomplete(input[split_pos..].trim_start(), app_meta),
                     Thing::Place(_) => {
                         Place::autocomplete(input[split_pos..].trim_start(), app_meta)
@@ -336,7 +336,7 @@ impl Autocomplete for WorldCommand {
                 suggestions.reserve(edit_suggestions.len());
 
                 edit_suggestions
-                    .drain(..)
+                    .into_iter()
                     .map(|(a, _)| {
                         (
                             format!("{}{}", &input[..split_pos], a).into(),
@@ -464,7 +464,7 @@ impl<T: Into<Thing>> From<ParsedThing<T>> for Thing {
 fn append_unknown_words_notice(
     mut output: String,
     input: &str,
-    mut unknown_words: Vec<Range<usize>>,
+    unknown_words: Vec<Range<usize>>,
 ) -> String {
     if !unknown_words.is_empty() {
         output.push_str(
@@ -486,7 +486,7 @@ fn append_unknown_words_notice(
         output.push_str("\\\n\u{a0}\u{a0}");
 
         {
-            let mut words = unknown_words.drain(..);
+            let mut words = unknown_words.into_iter();
             let mut unknown_word = words.next();
             for (i, _) in input.char_indices() {
                 if unknown_word.as_ref().map_or(false, |word| i >= word.end) {
@@ -592,7 +592,7 @@ mod test {
         )
         .unwrap();
 
-        vec![
+        [
             ("npc", "create person"),
             // Species
             ("dragonborn", "create dragonborn"),
@@ -607,7 +607,7 @@ mod test {
             // PlaceType
             ("inn", "create inn"),
         ]
-        .drain(..)
+        .into_iter()
         .for_each(|(word, summary)| {
             assert_eq!(
                 vec![(word.into(), summary.into())],
@@ -679,7 +679,7 @@ mod test {
     fn display_test() {
         let app_meta = app_meta();
 
-        vec![
+        [
             create(Place {
                 subtype: "inn".parse::<PlaceType>().ok().into(),
                 ..Default::default()
@@ -690,7 +690,7 @@ mod test {
                 ..Default::default()
             }),
         ]
-        .drain(..)
+        .into_iter()
         .for_each(|command| {
             let command_string = command.to_string();
             assert_ne!("", command_string);

--- a/core/src/world/demographics.rs
+++ b/core/src/world/demographics.rs
@@ -159,14 +159,14 @@ impl From<GroupMapWrapper> for GroupMap {
 }
 
 impl From<GroupMapSerialized> for GroupMapWrapper {
-    fn from(mut value: GroupMapSerialized) -> Self {
-        Self(value.drain(..).map(|(a, b, c)| ((a, b), c)).collect())
+    fn from(value: GroupMapSerialized) -> Self {
+        Self(value.into_iter().map(|(a, b, c)| ((a, b), c)).collect())
     }
 }
 
 impl From<GroupMapWrapper> for GroupMapSerialized {
-    fn from(mut value: GroupMapWrapper) -> Self {
-        value.0.drain().map(|((a, b), c)| (a, b, c)).collect()
+    fn from(value: GroupMapWrapper) -> Self {
+        value.0.into_iter().map(|((a, b), c)| (a, b, c)).collect()
     }
 }
 

--- a/core/tests/integration/storage/journal.rs
+++ b/core/tests/integration/storage/journal.rs
@@ -80,7 +80,7 @@ fn it_shows_alphabetized_results() {
     assert_eq!(Some(""), output_iter.next());
     assert_eq!(Some("## NPCs"), output_iter.next());
 
-    npcs.drain(..)
+    npcs.into_iter()
         .zip(output_iter.by_ref())
         .enumerate()
         .for_each(|(i, (a, b))| {
@@ -94,7 +94,7 @@ fn it_shows_alphabetized_results() {
     assert_eq!(Some(""), output_iter.next());
     assert_eq!(Some("## Places"), output_iter.next());
 
-    inns.drain(..)
+    inns.into_iter()
         .zip(output_iter.by_ref())
         .enumerate()
         .for_each(|(i, (a, b))| {

--- a/core/tests/integration/world/create_multiple.rs
+++ b/core/tests/integration/world/create_multiple.rs
@@ -92,7 +92,7 @@ fn numeric_aliases() {
     let generated_output = app.command("more").unwrap();
 
     // Doing this in two steps due to borrowing issues.
-    let mut outputs = generated_output
+    let outputs = generated_output
         .lines()
         .filter(|line| line.starts_with('~'))
         .map(|s| {
@@ -114,7 +114,7 @@ fn numeric_aliases() {
     assert_eq!(
         10,
         outputs
-            .drain(..)
+            .into_iter()
             .map(|(digit_output, name)| {
                 let name_output = app.command(&format!("load {}", name)).unwrap();
                 assert_eq!(digit_output, name_output);

--- a/reference/src/srd_5e/equipment/category.rs
+++ b/reference/src/srd_5e/equipment/category.rs
@@ -170,7 +170,7 @@ impl<'a> fmt::Display for MagicItemListView<'a> {
         magic_items.sort_by_key(|item| &item.name);
 
         magic_items
-            .drain(..)
+            .into_iter()
             .try_for_each(|item| write!(f, "\n* {}", item.display_summary()))?;
 
         Ok(())

--- a/reference/src/srd_5e/mod.rs
+++ b/reference/src/srd_5e/mod.rs
@@ -36,8 +36,8 @@ pub fn magic_items() -> Result<Vec<MagicItem>, String> {
     serde_json::from_str(include_str!(
         "../../../data/srd_5e/src/5e-SRD-Magic-Items.json",
     ))
-    .map(|mut v: Vec<MagicItem>| {
-        v.drain(..)
+    .map(|v: Vec<MagicItem>| {
+        v.into_iter()
             .filter(|magic_item| !magic_item.has_variants())
             .collect()
     })

--- a/reference/tests/integration/srd_5e_item_categories.rs
+++ b/reference/tests/integration/srd_5e_item_categories.rs
@@ -379,7 +379,7 @@ fn potions() {
 fn list_all_categories() {
     let mut categories: Vec<(String, Vec<String>)> = item_categories()
         .unwrap()
-        .drain(..)
+        .into_iter()
         .map(|category| {
             let mut names = vec![category.name()];
             names.append(&mut category.alt_names());


### PR DESCRIPTION
Previously, the return type of `ContextAwareParse::parse_input()` was `(Option<Self>, Vec<Self>)` with no real explanation of why. This has now been updated to a properly-documented struct called `CommandMatches<T>`. It also provides convenience functions for converting and combining multiple sets of matches, consolidating some (admittedly simple) logic that was previously scattered all over the place.

Normally I try to keep commits small and numerous in each branch, but this is one of those rip-the-bandaid changes.

Resolves #325.