### PR TITLE
Create new AutocompleteSuggestion struct

### DIFF
--- a/core/src/app/command/alias.rs
+++ b/core/src/app/command/alias.rs
@@ -1,8 +1,9 @@
-use super::{Autocomplete, Command, CommandMatches, ContextAwareParse, Runnable};
+use super::{
+    Autocomplete, AutocompleteSuggestion, Command, CommandMatches, ContextAwareParse, Runnable,
+};
 use crate::app::AppMeta;
 use crate::utils::CaseInsensitiveStr;
 use async_trait::async_trait;
-use std::borrow::Cow;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::mem;
@@ -131,17 +132,17 @@ impl ContextAwareParse for CommandAlias {
 
 #[async_trait(?Send)]
 impl Autocomplete for CommandAlias {
-    async fn autocomplete(
-        input: &str,
-        app_meta: &AppMeta,
-    ) -> Vec<(Cow<'static, str>, Cow<'static, str>)> {
+    async fn autocomplete(input: &str, app_meta: &AppMeta) -> Vec<AutocompleteSuggestion> {
         app_meta
             .command_aliases
             .iter()
             .filter_map(|command| match command {
                 Self::Literal { term, summary, .. } => {
                     if term.starts_with_ci(input) {
-                        Some((term.clone().into(), summary.clone().into()))
+                        Some(AutocompleteSuggestion::new(
+                            term.to_string(),
+                            summary.to_string(),
+                        ))
                     } else {
                         None
                     }

--- a/core/src/app/command/alias.rs
+++ b/core/src/app/command/alias.rs
@@ -4,6 +4,7 @@ use super::{
 use crate::app::AppMeta;
 use crate::utils::CaseInsensitiveStr;
 use async_trait::async_trait;
+use std::borrow::Cow;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::mem;
@@ -11,8 +12,8 @@ use std::mem;
 #[derive(Clone, Debug)]
 pub enum CommandAlias {
     Literal {
-        term: String,
-        summary: String,
+        term: Cow<'static, str>,
+        summary: Cow<'static, str>,
         command: Box<Command>,
     },
     StrictWildcard {
@@ -21,10 +22,14 @@ pub enum CommandAlias {
 }
 
 impl CommandAlias {
-    pub fn literal(term: String, summary: String, command: Command) -> Self {
+    pub fn literal(
+        term: impl Into<Cow<'static, str>>,
+        summary: impl Into<Cow<'static, str>>,
+        command: Command,
+    ) -> Self {
         Self::Literal {
-            term,
-            summary,
+            term: term.into(),
+            summary: summary.into(),
             command: Box::new(command),
         }
     }
@@ -323,10 +328,14 @@ mod tests {
         AppMeta::new(NullDataStore::default(), &event_dispatcher)
     }
 
-    fn literal(term: &str, summary: &str, command: Command) -> CommandAlias {
+    fn literal(
+        term: impl Into<Cow<'static, str>>,
+        summary: impl Into<Cow<'static, str>>,
+        command: Command,
+    ) -> CommandAlias {
         CommandAlias::Literal {
-            term: term.to_string(),
-            summary: summary.to_string(),
+            term: term.into(),
+            summary: summary.into(),
             command: Box::new(command),
         }
     }

--- a/core/src/app/command/mod.rs
+++ b/core/src/app/command/mod.rs
@@ -1,6 +1,8 @@
 pub use alias::CommandAlias;
 pub use app::AppCommand;
-pub use runnable::{Autocomplete, CommandMatches, ContextAwareParse, Runnable};
+pub use runnable::{
+    Autocomplete, AutocompleteSuggestion, CommandMatches, ContextAwareParse, Runnable,
+};
 pub use tutorial::TutorialCommand;
 
 #[cfg(test)]
@@ -18,7 +20,6 @@ use crate::time::TimeCommand;
 use crate::world::WorldCommand;
 use async_trait::async_trait;
 use futures::join;
-use std::borrow::Cow;
 use std::fmt;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -155,10 +156,7 @@ impl ContextAwareParse for Command {
 
 #[async_trait(?Send)]
 impl Autocomplete for Command {
-    async fn autocomplete(
-        input: &str,
-        app_meta: &AppMeta,
-    ) -> Vec<(Cow<'static, str>, Cow<'static, str>)> {
+    async fn autocomplete(input: &str, app_meta: &AppMeta) -> Vec<AutocompleteSuggestion> {
         let results = join!(
             CommandAlias::autocomplete(input, app_meta),
             AppCommand::autocomplete(input, app_meta),

--- a/core/src/app/command/tutorial.rs
+++ b/core/src/app/command/tutorial.rs
@@ -131,8 +131,8 @@ impl TutorialCommand {
             Self::Introduction | Self::Cancel { .. } | Self::Resume | Self::Restart { .. } => {}
             Self::GeneratingLocations => {
                 app_meta.command_aliases.insert(CommandAlias::literal(
-                    "next".to_string(),
-                    "continue the tutorial".to_string(),
+                    "next",
+                    "continue the tutorial",
                     Self::GeneratingLocations.into(),
                 ));
 
@@ -143,7 +143,7 @@ impl TutorialCommand {
             )),
             Self::GeneratingCharacters { inn_name } => {
                 app_meta.command_aliases.insert(CommandAlias::literal(
-                    "save".to_string(),
+                    "save",
                     format!("save {}", inn_name),
                     StorageCommand::Save {
                         name: inn_name.to_owned(),
@@ -169,7 +169,7 @@ impl TutorialCommand {
                 });
 
                 app_meta.command_aliases.insert(CommandAlias::literal(
-                    "more".to_string(),
+                    "more",
                     format!("create {}", thing.display_description()),
                     WorldCommand::CreateMultiple { thing }.into(),
                 ));
@@ -181,7 +181,7 @@ impl TutorialCommand {
             }
             Self::EditingCharacters { npc_name, .. } => {
                 app_meta.command_aliases.insert(CommandAlias::literal(
-                    "2".to_string(),
+                    "2",
                     format!("load {}", npc_name),
                     StorageCommand::Load {
                         name: npc_name.to_owned(),
@@ -196,7 +196,7 @@ impl TutorialCommand {
             }
             Self::TheJournal { npc_name, .. } => {
                 app_meta.command_aliases.insert(CommandAlias::literal(
-                    "save".to_string(),
+                    "save",
                     format!("save {}", npc_name),
                     StorageCommand::Save {
                         name: npc_name.to_owned(),
@@ -703,14 +703,14 @@ impl Runnable for TutorialCommand {
             };
 
             app_meta.command_aliases.insert(CommandAlias::literal(
-                "resume".to_string(),
-                "return to the tutorial".to_string(),
+                "resume",
+                "return to the tutorial",
                 Self::Resume.into(),
             ));
 
             app_meta.command_aliases.insert(CommandAlias::literal(
-                "restart".to_string(),
-                "restart the tutorial".to_string(),
+                "restart",
+                "restart the tutorial",
                 Self::Restart {
                     inn_name: self.inn_name(),
                     npc_name: self.npc_name(),
@@ -723,8 +723,8 @@ impl Runnable for TutorialCommand {
 
         if let Some(command) = next_command {
             app_meta.command_aliases.insert(CommandAlias::literal(
-                "cancel".to_string(),
-                "cancel the tutorial".to_string(),
+                "cancel",
+                "cancel the tutorial",
                 Self::Cancel {
                     inn_name: command.inn_name(),
                     npc_name: command.npc_name(),

--- a/core/src/app/command/tutorial.rs
+++ b/core/src/app/command/tutorial.rs
@@ -1,7 +1,7 @@
 use super::CommandType;
 use crate::app::{
-    AppCommand, AppMeta, Autocomplete, Command, CommandAlias, CommandMatches, ContextAwareParse,
-    Runnable,
+    AppCommand, AppMeta, Autocomplete, AutocompleteSuggestion, Command, CommandAlias,
+    CommandMatches, ContextAwareParse, Runnable,
 };
 use crate::reference::{ItemCategory, ReferenceCommand, Spell};
 use crate::storage::{Change, StorageCommand};
@@ -10,7 +10,6 @@ use crate::utils::CaseInsensitiveStr;
 use crate::world::npc::{Age, Ethnicity, Gender, Npc, Species};
 use crate::world::{ParsedThing, Thing, WorldCommand};
 use async_trait::async_trait;
-use std::borrow::Cow;
 use std::fmt;
 
 /// An enum representing each possible state of the tutorial. The Introduction variant is mapped to
@@ -755,12 +754,12 @@ impl ContextAwareParse for TutorialCommand {
 
 #[async_trait(?Send)]
 impl Autocomplete for TutorialCommand {
-    async fn autocomplete(
-        input: &str,
-        _app_meta: &AppMeta,
-    ) -> Vec<(Cow<'static, str>, Cow<'static, str>)> {
+    async fn autocomplete(input: &str, _app_meta: &AppMeta) -> Vec<AutocompleteSuggestion> {
         if "tutorial".starts_with_ci(input) {
-            vec![("tutorial".into(), "feature walkthrough".into())]
+            vec![AutocompleteSuggestion::new(
+                "tutorial",
+                "feature walkthrough",
+            )]
         } else {
             Vec::new()
         }

--- a/core/src/app/mod.rs
+++ b/core/src/app/mod.rs
@@ -1,5 +1,6 @@
 pub use command::{
-    AppCommand, Autocomplete, Command, CommandAlias, CommandMatches, ContextAwareParse, Runnable,
+    AppCommand, Autocomplete, AutocompleteSuggestion, Command, CommandAlias, CommandMatches,
+    ContextAwareParse, Runnable,
 };
 pub use meta::AppMeta;
 
@@ -12,7 +13,6 @@ mod meta;
 use crate::storage::backup::{import, BackupData};
 use crate::utils::CaseInsensitiveStr;
 use initiative_macros::motd;
-use std::borrow::Cow;
 
 /// The application wrapper. Its inner [`AppMeta`] object holds metadata associated with the
 /// application, including ephemeral storage of journal entries and the object representing the
@@ -71,9 +71,9 @@ impl App {
     /// case.
     ///
     /// Returns a maximum of 10 results.
-    pub async fn autocomplete(&self, input: &str) -> Vec<(Cow<'static, str>, Cow<'static, str>)> {
+    pub async fn autocomplete(&self, input: &str) -> Vec<AutocompleteSuggestion> {
         let mut suggestions: Vec<_> = Command::autocomplete(input, &self.meta).await;
-        suggestions.sort_by(|(a, _), (b, _)| a.cmp_ci(b));
+        suggestions.sort_by(|a, b| a.term.cmp_ci(&b.term));
         suggestions.truncate(10);
         suggestions
     }

--- a/core/src/reference/command.rs
+++ b/core/src/reference/command.rs
@@ -1,9 +1,10 @@
 use super::{Condition, Item, ItemCategory, MagicItem, Spell, Trait};
-use crate::app::{AppMeta, Autocomplete, CommandMatches, ContextAwareParse, Runnable};
+use crate::app::{
+    AppMeta, Autocomplete, AutocompleteSuggestion, CommandMatches, ContextAwareParse, Runnable,
+};
 use crate::utils::CaseInsensitiveStr;
 use async_trait::async_trait;
 use caith::Roller;
-use std::borrow::Cow;
 use std::fmt;
 use std::iter::repeat;
 
@@ -114,10 +115,7 @@ impl ContextAwareParse for ReferenceCommand {
 
 #[async_trait(?Send)]
 impl Autocomplete for ReferenceCommand {
-    async fn autocomplete(
-        input: &str,
-        _app_meta: &AppMeta,
-    ) -> Vec<(Cow<'static, str>, Cow<'static, str>)> {
+    async fn autocomplete(input: &str, _app_meta: &AppMeta) -> Vec<AutocompleteSuggestion> {
         [
             ("Open Game License", "SRD license"),
             ("spells", "SRD index"),
@@ -129,9 +127,9 @@ impl Autocomplete for ReferenceCommand {
         .chain(ItemCategory::get_words().zip(repeat("SRD item category")))
         .chain(MagicItem::get_words().zip(repeat("SRD magic item")))
         .chain(Trait::get_words().zip(repeat("SRD trait")))
-        .filter(|(s, _)| s.starts_with_ci(input))
+        .filter(|(term, _)| term.starts_with_ci(input))
         .take(10)
-        .map(|(a, b)| (a.into(), b.into()))
+        .map(|(term, summary)| AutocompleteSuggestion::new(term, summary))
         .collect()
     }
 }

--- a/core/src/storage/command.rs
+++ b/core/src/storage/command.rs
@@ -143,7 +143,7 @@ impl Runnable for StorageCommand {
                 let output = if let Ok(thing) = thing {
                     if thing.uuid().is_none() {
                         save_command = Some(CommandAlias::literal(
-                            "save".to_string(),
+                            "save",
                             format!("save {}", name),
                             StorageCommand::Save { name }.into(),
                         ));

--- a/core/src/world/command/mod.rs
+++ b/core/src/world/command/mod.rs
@@ -78,7 +78,7 @@ impl Runnable for WorldCommand {
                                 ));
 
                             command_alias = Some(CommandAlias::literal(
-                                "save".to_string(),
+                                "save",
                                 format!("save {}", name),
                                 StorageCommand::Save {
                                     name: name.to_string(),
@@ -87,7 +87,7 @@ impl Runnable for WorldCommand {
                             ));
 
                             app_meta.command_aliases.insert(CommandAlias::literal(
-                                "more".to_string(),
+                                "more",
                                 format!("create {}", diff.display_description()),
                                 WorldCommand::CreateMultiple {
                                     thing: diff.clone(),
@@ -191,7 +191,7 @@ impl Runnable for WorldCommand {
                 }
 
                 app_meta.command_aliases.insert(CommandAlias::literal(
-                    "more".to_string(),
+                    "more",
                     format!("create {}", thing.display_description()),
                     Self::CreateMultiple { thing }.into(),
                 ));

--- a/core/tests/common/mod.rs
+++ b/core/tests/common/mod.rs
@@ -1,5 +1,5 @@
+use initiative_core::app::AutocompleteSuggestion;
 use initiative_core::{app, App, BackupData, DataStore, Event, MemoryDataStore, NullDataStore};
-use std::borrow::Cow;
 use tokio_test::block_on;
 
 pub fn get_name(output: &str) -> String {
@@ -55,7 +55,7 @@ impl SyncApp {
         block_on(self.0.command(input))
     }
 
-    pub fn autocomplete(&self, input: &str) -> Vec<(Cow<'static, str>, Cow<'static, str>)> {
+    pub fn autocomplete(&self, input: &str) -> Vec<AutocompleteSuggestion> {
         block_on(self.0.autocomplete(input))
     }
 

--- a/core/tests/integration/app/mod.rs
+++ b/core/tests/integration/app/mod.rs
@@ -2,7 +2,7 @@ mod app;
 mod tutorial;
 
 use crate::common::{get_name, sync_app};
-use std::borrow::Cow;
+use initiative_core::app::AutocompleteSuggestion;
 
 #[test]
 fn autocomplete_command() {
@@ -20,13 +20,13 @@ fn autocomplete_command() {
             ("desert", "create desert"),
         ]
         .into_iter()
-        .map(|(a, b)| (a.into(), b.into()))
+        .map(|(term, summary)| AutocompleteSuggestion::new(term, summary))
         .collect::<Vec<_>>(),
         sync_app().autocomplete("d"),
     );
 
     assert_eq!(
-        Vec::<(Cow<'static, str>, Cow<'static, str>)>::new(),
+        Vec::<AutocompleteSuggestion>::new(),
         sync_app().autocomplete("potato")
     )
 }
@@ -41,9 +41,9 @@ fn autocomplete_proper_noun() {
     let autocomplete_results = app.autocomplete(query);
 
     assert!(
-        autocomplete_results.contains(&(
-            npc_name.to_string().into(),
-            format!("{} (unsaved)", npc_description).into(),
+        autocomplete_results.contains(&AutocompleteSuggestion::new(
+            npc_name.to_string(),
+            format!("{} (unsaved)", npc_description),
         )),
         "Generator output:\n{}\n\nQuery: {}\nResults: {:?}",
         output,

--- a/core/tests/integration/reference/condition.rs
+++ b/core/tests/integration/reference/condition.rs
@@ -1,4 +1,5 @@
 use crate::common::sync_app;
+use initiative_core::app::AutocompleteSuggestion;
 
 #[test]
 fn stunned() {
@@ -19,7 +20,7 @@ fn stunned() {
     assert_eq!(output, sync_app().command("srd condition Stunned").unwrap());
 
     assert_eq!(
-        vec![("Stunned".into(), "SRD condition".into())],
+        vec![AutocompleteSuggestion::new("Stunned", "SRD condition")],
         sync_app().autocomplete("stunned"),
     );
 }

--- a/core/tests/integration/reference/item.rs
+++ b/core/tests/integration/reference/item.rs
@@ -1,4 +1,5 @@
 use crate::common::sync_app;
+use initiative_core::app::AutocompleteSuggestion;
 
 #[test]
 fn light_crossbow() {
@@ -25,7 +26,7 @@ fn light_crossbow() {
     );
 
     assert_eq!(
-        vec![("Light Crossbow".into(), "SRD item".into())],
+        vec![AutocompleteSuggestion::new("Light Crossbow", "SRD item")],
         sync_app().autocomplete("light crossbow"),
     );
 }

--- a/core/tests/integration/reference/item_category.rs
+++ b/core/tests/integration/reference/item_category.rs
@@ -1,4 +1,5 @@
 use crate::common::sync_app;
+use initiative_core::app::AutocompleteSuggestion;
 
 #[test]
 fn weapons() {
@@ -52,7 +53,10 @@ fn weapons() {
     );
 
     assert_eq!(
-        vec![("melee weapons".into(), "SRD item category".into())],
+        vec![AutocompleteSuggestion::new(
+            "melee weapons",
+            "SRD item category",
+        )],
         sync_app().autocomplete("melee weapons"),
     );
 }
@@ -108,7 +112,10 @@ fn magic_weapons() {
     );
 
     assert_eq!(
-        vec![("magic weapons".into(), "SRD item category".into())],
+        vec![AutocompleteSuggestion::new(
+            "magic weapons",
+            "SRD item category",
+        )],
         sync_app().autocomplete("magic weapons"),
     );
 }

--- a/core/tests/integration/reference/magic_item.rs
+++ b/core/tests/integration/reference/magic_item.rs
@@ -1,4 +1,5 @@
 use crate::common::sync_app;
+use initiative_core::app::AutocompleteSuggestion;
 
 #[test]
 fn rod_of_rulership() {
@@ -24,7 +25,10 @@ You can use an action to present the rod and command obedience from each creatur
     );
 
     assert_eq!(
-        vec![("Rod of Rulership".into(), "SRD magic item".into())],
+        vec![AutocompleteSuggestion::new(
+            "Rod of Rulership",
+            "SRD magic item",
+        )],
         sync_app().autocomplete("rod of rulership"),
     );
 }

--- a/core/tests/integration/reference/open_game_license.rs
+++ b/core/tests/integration/reference/open_game_license.rs
@@ -1,4 +1,5 @@
 use crate::common::sync_app;
+use initiative_core::app::AutocompleteSuggestion;
 
 #[test]
 fn open_game_license() {
@@ -12,7 +13,10 @@ fn open_game_license() {
     );
 
     assert_eq!(
-        vec![("Open Game License".into(), "SRD license".into())],
+        vec![AutocompleteSuggestion::new(
+            "Open Game License",
+            "SRD license",
+        )],
         sync_app().autocomplete("open game license"),
     );
 }

--- a/core/tests/integration/reference/spell.rs
+++ b/core/tests/integration/reference/spell.rs
@@ -1,4 +1,5 @@
 use crate::common::sync_app;
+use initiative_core::app::AutocompleteSuggestion;
 
 #[test]
 fn speak_with_animals() {
@@ -26,7 +27,10 @@ You gain the ability to comprehend and verbally communicate with beasts for the 
     );
 
     assert_eq!(
-        vec![("Speak with Animals".into(), "SRD spell".into())],
+        vec![AutocompleteSuggestion::new(
+            "Speak with Animals",
+            "SRD spell",
+        )],
         sync_app().autocomplete("speak with animals"),
     );
 }
@@ -62,5 +66,5 @@ You touch a willing creature to grant it the ability to see in the dark. For the
     assert!(sync_app()
         .autocomplete("darkvision")
         .iter()
-        .any(|item| item == &("Darkvision".into(), "SRD spell".into())));
+        .any(|suggestion| suggestion.term == "Darkvision" && suggestion.summary == "SRD spell"));
 }

--- a/core/tests/integration/reference/spells.rs
+++ b/core/tests/integration/reference/spells.rs
@@ -1,4 +1,5 @@
 use crate::common::sync_app;
+use initiative_core::app::AutocompleteSuggestion;
 
 #[test]
 fn spells() {
@@ -17,7 +18,7 @@ fn spells() {
     assert_eq!(322, output.lines().count(), "{}", output);
 
     assert_eq!(
-        vec![("spells".into(), "SRD index".into())],
+        vec![AutocompleteSuggestion::new("spells", "SRD index")],
         sync_app().autocomplete("Spells"),
     );
 }

--- a/core/tests/integration/reference/traits.rs
+++ b/core/tests/integration/reference/traits.rs
@@ -1,4 +1,5 @@
 use crate::common::sync_app;
+use initiative_core::app::AutocompleteSuggestion;
 
 #[test]
 fn stonecunning() {
@@ -15,7 +16,7 @@ Whenever you make an Intelligence (History) check related to the origin of stone
     );
 
     assert_eq!(
-        vec![("Stonecunning".into(), "SRD trait".into())],
+        vec![AutocompleteSuggestion::new("Stonecunning", "SRD trait")],
         sync_app().autocomplete("stonecunning"),
     );
 }
@@ -47,13 +48,16 @@ You have superior vision in dark and dim conditions. You can see in dim light wi
     assert!(sync_app()
         .autocomplete("darkvision")
         .iter()
-        .any(|item| item == &("Darkvision".into(), "SRD trait".into())));
+        .any(|suggestion| suggestion.term == "Darkvision" && suggestion.summary == "SRD trait"));
 }
 
 #[test]
 fn draconic_ancestry() {
     assert_eq!(
-        vec![("Draconic Ancestry".into(), "SRD trait".into())],
+        vec![AutocompleteSuggestion::new(
+            "Draconic Ancestry",
+            "SRD trait",
+        )],
         sync_app().autocomplete("draconic ancestry"),
     );
 }

--- a/core/tests/integration/storage/undo_redo.rs
+++ b/core/tests/integration/storage/undo_redo.rs
@@ -1,5 +1,5 @@
 use crate::common::{sync_app, SyncApp};
-use std::borrow::Cow;
+use initiative_core::app::AutocompleteSuggestion;
 
 fn undo_redo_test(
     app: &mut SyncApp,
@@ -16,7 +16,10 @@ fn undo_redo_test(
 
     {
         assert_eq!(
-            Some(&(Cow::from("undo"), Cow::from(expect_undo_autocomplete))),
+            Some(&AutocompleteSuggestion::new(
+                "undo",
+                expect_undo_autocomplete.to_string(),
+            )),
             app.autocomplete("undo").first(),
         );
 
@@ -33,7 +36,10 @@ fn undo_redo_test(
 
     {
         assert_eq!(
-            Some(&(Cow::from("redo"), Cow::from(expect_redo_autocomplete))),
+            Some(&AutocompleteSuggestion::new(
+                "redo",
+                expect_redo_autocomplete.to_string(),
+            )),
             app.autocomplete("redo").first(),
         );
 
@@ -55,13 +61,13 @@ fn undo_redo_test(
 fn nothing() {
     assert_eq!("Nothing to undo.", sync_app().command("undo").unwrap_err());
     assert_eq!(
-        Some(&(Cow::from("undo"), Cow::from("Nothing to undo."))),
+        Some(&AutocompleteSuggestion::new("undo", "Nothing to undo.")),
         sync_app().autocomplete("undo").first(),
     );
 
     assert_eq!("Nothing to redo.", sync_app().command("redo").unwrap_err());
     assert_eq!(
-        Some(&(Cow::from("redo"), Cow::from("Nothing to redo."))),
+        Some(&AutocompleteSuggestion::new("redo", "Nothing to redo.")),
         sync_app().autocomplete("redo").first(),
     );
 }


### PR DESCRIPTION
Rather than returning the confusing tuple `(Cow<'static, str>, Cow<'static, str>)` from `Autocomplete::autocomplete()`, create a new `AutocompleteSuggestion` struct to better abstract the implementation. The result is occasionally more verbose but hopefully much clearer to read. It has the side benefit of removing a ton of silly `.into()`s.

Resolves #326.