### PR TITLE
Fix failing ne_ci() unit test

### DIFF
--- a/core/src/utils/case_insensitive_str.rs
+++ b/core/src/utils/case_insensitive_str.rs
@@ -122,15 +122,15 @@ mod test {
         assert!("!@#".eq_ci("!@#"));
         assert!("p🥔tat🥔".eq_ci("P🥔TAT🥔"));
 
-        assert!("abcd".ne_ci("abc"));
-        assert!("abc".ne_ci("abcd"));
-        assert!("".ne_ci("🥔"));
-        assert!("🥔".ne_ci(""));
-        assert!("🥔".ne_ci("potato"));
-        assert!("potato".ne_ci("🥔"));
-        assert!("SS".ne_ci("ß"));
-        assert!("ß".ne_ci("S"));
-        assert!("S".ne_ci("ß"));
+        assert!(!"abcd".eq_ci("abc"));
+        assert!(!"abc".eq_ci("abcd"));
+        assert!(!"".eq_ci("🥔"));
+        assert!(!"🥔".eq_ci(""));
+        assert!(!"🥔".eq_ci("potato"));
+        assert!(!"potato".eq_ci("🥔"));
+        assert!(!"SS".eq_ci("ß"));
+        assert!(!"ß".eq_ci("S"));
+        assert!(!"S".eq_ci("ß"));
     }
 
     #[test]

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -88,6 +88,7 @@ fn set_root_element_id(element_id: String) {
 }
 
 fn get_root_element() -> Option<Element> {
+    #[allow(static_mut_refs)]
     if let Some(element_id) = unsafe { &ROOT_ELEMENT_ID } {
         window()
             .and_then(|w| w.document())


### PR DESCRIPTION
Lesson (re)learned: just because the lint says "dead code" doesn't mean you didn't write unit tests. Also, let your darn tests finish before merging.