### PR TITLE
Fix rustfmt checking files twice

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Update Rust
         run: rustc --version && rustup update
       - name: Run rustfmt
-        run: git ls-files '*.rs' | xargs rustfmt --check --edition 2021 --verbose
+        run: rustfmt --check --edition 2021 --verbose */src/{lib,main}.rs
       - name: Verify no mangled parens
         run: if git grep ',)' '*.rs'; then exit 1; fi
       - name: Run Clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Update Rust
         run: rustc --version && rustup update
       - name: Run rustfmt
-        run: rustfmt --check --edition 2021 --verbose */src/{lib,main}.rs
+        run: rustfmt --check --edition 2021 --verbose */src/{lib,main}.rs */tests/*.rs
       - name: Verify no mangled parens
         run: if git grep ',)' '*.rs'; then exit 1; fi
       - name: Run Clippy


### PR DESCRIPTION
Apparently rustfmt tests the entire code tree when pointed at `lib.rs`, so all files were being checked twice (except lib itself, I guess). The `git ls-files` song and dance was unnecessary, just point it at `{lib,main}.rs` and let 'er rip.