### PR TITLE
Reuse thing boxes when editing

### DIFF
--- a/core/src/world/npc/view.rs
+++ b/core/src/world/npc/view.rs
@@ -97,7 +97,13 @@ impl<'a> fmt::Display for DetailsView<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { npc, relations } = self;
 
-        writeln!(f, "<div class=\"thing-box npc\">\n")?;
+        writeln!(
+            f,
+            "<div class=\"thing-box npc\"{}>\n",
+            npc.uuid
+                .clone()
+                .map_or("".to_string(), |v| format!(" data-uuid=\"{}\"", v))
+        )?;
 
         npc.name
             .value()

--- a/core/src/world/place/view.rs
+++ b/core/src/world/place/view.rs
@@ -80,7 +80,14 @@ impl<'a> fmt::Display for DetailsView<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { place, relations } = self;
 
-        writeln!(f, "<div class=\"thing-box place\">\n")?;
+        writeln!(
+            f,
+            "<div class=\"thing-box place\"{}>\n",
+            place
+                .uuid
+                .clone()
+                .map_or("".to_string(), |v| format!(" data-uuid=\"{}\"", v))
+        )?;
 
         place
             .name


### PR DESCRIPTION
This pull request aims to address the enhancement put forward in #190.

The approach is as follows:
1. Have `/core/src/world/{npc,place}/view.rs` append the `uuid` of the Thing as a property of the `thing-box` element called `data-uuid`. (9b1391c217398f7a182fc8f324ba8701b2cac8c9)
2. In `/web/js/terminal.js`, intercept the output and check to see if the most recent thing-box element has a matching `data-uuid` property.
3. If it's a match, perform a diff of the two elements, flagging the changed fields with a class.
4. Use the class to add some styles for visual feedback.