### PR TITLE
Migrate `about` command to new architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,7 @@ name = "initiative-macros"
 version = "0.1.0"
 dependencies = [
  "initiative-reference",
+ "proc-macro2",
  "quote",
  "regex",
  "syn",
@@ -557,11 +558,11 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -848,6 +849,12 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,23 +28,24 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -40,7 +56,7 @@ checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -48,6 +64,21 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
 
 [[package]]
 name = "bitflags"
@@ -206,7 +237,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -265,13 +296,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
+name = "gimli"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "initiative-cli"
@@ -286,6 +320,7 @@ dependencies = [
 name = "initiative-core"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "async-trait",
  "caith",
  "futures",
@@ -294,6 +329,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "tokio",
  "tokio-test",
  "uuid",
 ]
@@ -306,7 +342,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -370,9 +406,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libm"
@@ -411,15 +447,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "mio"
-version = "0.8.11"
+name = "miniz_oxide"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi",
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -433,26 +478,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "numtoa"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
-name = "once_cell"
-version = "1.8.0"
+name = "object"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -512,7 +550,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -528,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -576,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -669,6 +707,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,7 +747,7 @@ checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -752,12 +796,12 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -769,6 +813,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -785,33 +840,31 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
- "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -907,7 +960,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.75",
  "wasm-bindgen-shared",
 ]
 
@@ -941,7 +994,7 @@ checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.75",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -987,28 +1040,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,26 +1056,27 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1055,9 +1087,9 @@ checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1067,9 +1099,9 @@ checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1079,9 +1111,15 @@ checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1091,9 +1129,9 @@ checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1103,9 +1141,9 @@ checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1115,9 +1153,9 @@ checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1127,6 +1165,6 @@ checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,9 +18,11 @@ serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "0.8", features = ["v4", "serde"] }
 
 initiative-macros = { path = "../macros" }
+async-stream = "0.3.5"
 
 [dev-dependencies]
 serde_json = "1.0"
+tokio = { version = "1.40.0", features = ["rt"] }
 tokio-test = "0.4"
 
 [features]

--- a/core/src/app/command/runnable.rs
+++ b/core/src/app/command/runnable.rs
@@ -39,7 +39,7 @@ pub fn assert_autocomplete(
     assert_eq!(expected, actual);
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(into = "(Cow<'static, str>, Cow<'static, str>)")]
 pub struct AutocompleteSuggestion {
     pub term: Cow<'static, str>,

--- a/core/src/command/about.rs
+++ b/core/src/command/about.rs
@@ -1,0 +1,68 @@
+use crate::command::prelude::*;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct About;
+
+impl Command for About {
+    fn token<'a>(&self) -> Token {
+        Token::keyword("about")
+    }
+
+    fn autocomplete(
+        &self,
+        _fuzzy_match: FuzzyMatch,
+        _input: &str,
+    ) -> Option<AutocompleteSuggestion> {
+        Some(("about", "about initiative.sh").into())
+    }
+
+    fn get_priority(&self, _token_match: &TokenMatch) -> Option<CommandPriority> {
+        Some(CommandPriority::Canonical)
+    }
+
+    fn get_canonical_form_of(&self, _token_match: &TokenMatch) -> Option<String> {
+        Some("about".to_string())
+    }
+
+    async fn run(
+        &self,
+        _token_match: TokenMatch<'_>,
+        _app_meta: &mut AppMeta,
+    ) -> Result<String, String> {
+        Ok(include_str!("../../../data/about.md")
+            .trim_end()
+            .to_string())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::token::test::assert_stream_eq;
+    use super::*;
+
+    use crate::app::{AppMeta, Event};
+    use crate::storage::NullDataStore;
+
+    #[tokio::test]
+    async fn run_test() {
+        let mut app_meta = AppMeta::new(NullDataStore, &event_dispatcher);
+
+        assert!(crate::command::run("about", &mut app_meta)
+            .await
+            .unwrap()
+            .contains("About initiative.sh"));
+    }
+
+    #[tokio::test]
+    async fn autocomplete_test() {
+        let app_meta = AppMeta::new(NullDataStore, &event_dispatcher);
+
+        assert_stream_eq(
+            vec![AutocompleteSuggestion::new("about", "about initiative.sh")],
+            About.parse_autocomplete("a", &app_meta),
+        )
+        .await;
+    }
+
+    fn event_dispatcher(_event: Event) {}
+}

--- a/core/src/command/mod.rs
+++ b/core/src/command/mod.rs
@@ -1,0 +1,273 @@
+/// All of the classes needed to implement a new command or token type.
+#[expect(unused_imports)]
+mod prelude {
+    pub use super::token::{FuzzyMatch, MatchMeta, Token, TokenMatch, TokenType};
+    pub use super::{Command, CommandPriority};
+    pub use crate::app::{AppMeta, AutocompleteSuggestion};
+}
+
+mod about;
+
+mod token;
+
+use std::fmt::{self, Write};
+use std::iter;
+use std::pin::Pin;
+
+use crate::app::{
+    AppMeta, Autocomplete, AutocompleteSuggestion, CommandMatches, ContextAwareParse, Runnable,
+};
+use initiative_macros::CommandList;
+
+use token::{FuzzyMatch, Token, TokenMatch};
+
+use async_stream::stream;
+use async_trait::async_trait;
+use futures::prelude::*;
+
+pub trait Command {
+    /// Return a single Token representing the command's syntax. If multiple commands are possible,
+    /// Token::Or can be used as a wrapper to cover the options.
+    fn token(&self) -> Token;
+
+    /// Convert a matched token into a suggestion to be displayed to the user. Note that this
+    /// method is not async; any metadata that may be needed for the autocomplete should be fetched
+    /// during the match_input step of the token and embedded in the match_meta property of the
+    /// TokenMatch object.
+    fn autocomplete(&self, fuzzy_match: FuzzyMatch, input: &str) -> Option<AutocompleteSuggestion>;
+
+    /// Get the priority of the command with a given input. See CommandPriority for details.
+    fn get_priority(&self, token_match: &TokenMatch) -> Option<CommandPriority>;
+
+    /// Run the command represented by a matched token, returning the success or failure output to
+    /// be displayed to the user.
+    async fn run(&self, token_match: TokenMatch, app_meta: &mut AppMeta) -> Result<String, String>;
+
+    /// Get the canonical form of the provided token match. Return None if the match is invalid.
+    fn get_canonical_form_of(&self, token_match: &TokenMatch) -> Option<String>;
+
+    /// A helper function to roughly provide Command::autocomplete(Command::token().match_input()),
+    /// except that that wouldn't compile for all sorts of exciting reasons.
+    fn parse_autocomplete<'a>(
+        &'a self,
+        input: &'a str,
+        app_meta: &'a AppMeta,
+    ) -> Pin<Box<dyn Stream<Item = AutocompleteSuggestion> + 'a>> {
+        Box::pin(stream! {
+            let token = self.token();
+            for await token_match in token.match_input(input, app_meta) {
+                if !matches!(token_match, FuzzyMatch::Overflow(..)) {
+                    if let Some(suggestion) = self.autocomplete(token_match, input) {
+                        yield suggestion;
+                    }
+                }
+            }
+        })
+    }
+}
+
+#[derive(Clone, CommandList, Debug)]
+enum CommandList {
+    About(about::About),
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum CommandPriority {
+    /// There should be no more than one canonical command per input, distinguished by a unique
+    /// prefix. The canonical command will always run if matched. If fuzzy matches also exist, they
+    /// will be indicated after the output of the canonical command.
+    Canonical,
+
+    /// There may be multiple fuzzy matches for a given input. If no canonical command exists AND
+    /// only one fuzzy match is found, that match will run. If multiple fuzzy matches are found,
+    /// the user will be prompted which canonical form they wish to run.
+    Fuzzy,
+}
+
+/// Interfaces with the legacy command traits.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TransitionalCommand {
+    canonical: String,
+}
+
+impl TransitionalCommand {
+    pub fn new<S>(canonical: S) -> Self
+    where
+        S: AsRef<str>,
+    {
+        Self {
+            canonical: canonical.as_ref().to_string(),
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl Runnable for TransitionalCommand {
+    async fn run(self, _input: &str, app_meta: &mut AppMeta) -> Result<String, String> {
+        run(&self.canonical, app_meta).await
+    }
+}
+
+#[async_trait(?Send)]
+impl ContextAwareParse for TransitionalCommand {
+    async fn parse_input(input: &str, app_meta: &AppMeta) -> CommandMatches<Self> {
+        let mut command_matches = CommandMatches::default();
+
+        let commands_tokens: Vec<(&CommandList, Token)> = CommandList::get_all()
+            .iter()
+            .map(|c| (c, c.token()))
+            .collect();
+
+        {
+            let mut match_streams = stream::SelectAll::default();
+
+            // Indexing the array avoids lifetime issues that would occur with an iterator
+            #[expect(clippy::needless_range_loop)]
+            for i in 0..commands_tokens.len() {
+                match_streams.push(
+                    stream::repeat(commands_tokens[i].0)
+                        .zip(commands_tokens[i].1.match_input(input, app_meta)),
+                );
+            }
+
+            while let Some((command, fuzzy_match)) = match_streams.next().await {
+                if let FuzzyMatch::Exact(token_match) = fuzzy_match {
+                    if let Some(priority) = command.get_priority(&token_match) {
+                        if let Some(canonical) = command.get_canonical_form_of(&token_match) {
+                            if priority == CommandPriority::Canonical {
+                                command_matches.push_canonical(Self { canonical });
+                            } else {
+                                command_matches.push_fuzzy(Self { canonical });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        command_matches
+    }
+}
+
+#[async_trait(?Send)]
+impl Autocomplete for TransitionalCommand {
+    async fn autocomplete(input: &str, app_meta: &AppMeta) -> Vec<AutocompleteSuggestion> {
+        autocomplete(input, app_meta).await
+    }
+}
+
+impl fmt::Display for TransitionalCommand {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.canonical)
+    }
+}
+
+pub async fn autocomplete(input: &str, app_meta: &AppMeta) -> Vec<AutocompleteSuggestion> {
+    let mut suggestions: Vec<_> = stream::select_all(
+        CommandList::get_all()
+            .iter()
+            .map(|c| c.parse_autocomplete(input, app_meta)),
+    )
+    .collect()
+    .await;
+
+    suggestions.sort();
+    suggestions.truncate(10);
+    suggestions
+}
+
+pub async fn run(input: &str, app_meta: &mut AppMeta) -> Result<String, String> {
+    // The only reason this vec exists is to ensure that the Tokens referenced by TokenMatch et al
+    // outlive their references.
+    let commands_tokens: Vec<(&CommandList, Token)> = CommandList::get_all()
+        .iter()
+        .map(|c| (c, c.token()))
+        .collect();
+
+    let mut token_matches: Vec<(&CommandList, CommandPriority, TokenMatch)> = Vec::new();
+
+    {
+        let mut match_streams = stream::SelectAll::default();
+
+        // Indexing the array avoids lifetime issues that would occur with an iterator
+        #[expect(clippy::needless_range_loop)]
+        for i in 0..commands_tokens.len() {
+            match_streams.push(
+                stream::repeat(commands_tokens[i].0)
+                    .zip(commands_tokens[i].1.match_input(input, app_meta)),
+            );
+        }
+
+        while let Some((command, fuzzy_match)) = match_streams.next().await {
+            if let Some(token_match) = fuzzy_match.into_exact() {
+                if let Some(priority) = command.get_priority(&token_match) {
+                    token_matches.push((command, priority, token_match));
+                }
+            }
+        }
+    }
+
+    token_matches.sort_by_key(|&(_, command_priority, _)| command_priority);
+
+    match token_matches.len() {
+        0 => return Err(format!("Unknown command: \"{}\"", input)),
+        1 => {
+            let (command, _, token_match) = token_matches.pop().unwrap();
+            return command.run(token_match, app_meta).await;
+        }
+        _ => {} // continue
+    }
+
+    if token_matches[0].1 == CommandPriority::Canonical {
+        assert_ne!(token_matches[1].1, CommandPriority::Canonical);
+
+        let (command, _, token_match) = token_matches.remove(0);
+        let result = command.run(token_match, app_meta).await;
+
+        let mut iter = token_matches
+            .iter()
+            .take_while(|(_, command_priority, _)| command_priority == &CommandPriority::Fuzzy)
+            .peekable();
+
+        if iter.peek().is_none() {
+            result
+        } else {
+            let f = |s| {
+                iter
+                    .filter_map(|(command, _, token_match)| command.get_canonical_form_of(token_match))
+                    .fold(
+                        format!("{}\n\n! There are other possible interpretations of this command. Did you mean:\n", s),
+                        |mut s, c| { write!(s, "\n* `{}`", c).unwrap(); s }
+                    )
+            };
+
+            match result {
+                Ok(s) => Ok(f(s)),
+                Err(s) => Err(f(s)),
+            }
+        }
+    } else {
+        let first_token_match = token_matches.remove(0);
+
+        let mut iter =
+            iter::once(&first_token_match)
+                .chain(token_matches.iter().take_while(|(_, command_priority, _)| {
+                    command_priority == &first_token_match.1
+                }))
+                .filter_map(|(command, _, token_match)| command.get_canonical_form_of(token_match))
+                .peekable();
+
+        if iter.peek().is_none() {
+            Err(format!("Unknown command: \"{}\"", input))
+        } else {
+            Err(iter.fold(
+                "There are several possible interpretations of this command. Did you mean:\n"
+                    .to_string(),
+                |mut s, c| {
+                    write!(s, "\n* `{}`", c).unwrap();
+                    s
+                },
+            ))
+        }
+    }
+}

--- a/core/src/command/token/keyword.rs
+++ b/core/src/command/token/keyword.rs
@@ -1,0 +1,116 @@
+use crate::command::prelude::*;
+use crate::utils::{quoted_words, CaseInsensitiveStr};
+
+use std::pin::Pin;
+
+use async_stream::stream;
+use futures::prelude::*;
+
+pub fn match_input<'a>(
+    token: &'a Token,
+    input: &'a str,
+) -> Pin<Box<dyn Stream<Item = FuzzyMatch<'a>> + 'a>> {
+    #[expect(irrefutable_let_patterns)]
+    let TokenType::Keyword(keyword) = token.token_type
+    else {
+        unreachable!();
+    };
+
+    Box::pin(stream! {
+        let mut iter = quoted_words(input);
+        if let Some(first_word) = iter.next() {
+            if keyword.eq_ci(first_word.as_str()) {
+                if first_word.is_at_end() {
+                    yield FuzzyMatch::Exact(token.into());
+                } else {
+                    yield FuzzyMatch::Overflow(token.into(), first_word.after());
+                }
+            } else if first_word.can_complete() {
+                if let Some(completion) = keyword.strip_prefix_ci(first_word) {
+                    yield FuzzyMatch::Partial(token.into(), Some(completion.to_string()));
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use crate::app::{AppMeta, Event};
+    use crate::storage::NullDataStore;
+
+    #[tokio::test]
+    async fn match_input_test_exact() {
+        let token = Token {
+            token_type: TokenType::Keyword("Nott"),
+            marker: Some(20),
+        };
+
+        assert_eq!(
+            &[FuzzyMatch::Exact((&token).into())][..],
+            token
+                .match_input("nott", &app_meta())
+                .collect::<Vec<_>>()
+                .await,
+        );
+    }
+
+    #[tokio::test]
+    async fn match_input_test_overflow() {
+        let token = Token {
+            token_type: TokenType::Keyword("Nott"),
+            marker: Some(20),
+        };
+
+        assert_eq!(
+            &[FuzzyMatch::Overflow(
+                (&token).into(),
+                " \"the brave\"".into(),
+            )][..],
+            token
+                .match_input("nott \"the brave\"", &app_meta())
+                .collect::<Vec<_>>()
+                .await,
+        );
+    }
+
+    #[tokio::test]
+    async fn match_input_test_partial() {
+        let token = Token {
+            token_type: TokenType::Keyword("Nott"),
+            marker: Some(20),
+        };
+
+        assert_eq!(
+            &[FuzzyMatch::Partial((&token).into(), Some("tt".to_string()))][..],
+            token
+                .match_input(" no", &app_meta())
+                .collect::<Vec<_>>()
+                .await,
+        );
+
+        assert_eq!(
+            Vec::<FuzzyMatch>::new(),
+            token
+                .match_input(" no ", &app_meta())
+                .collect::<Vec<_>>()
+                .await,
+        );
+
+        assert_eq!(
+            Vec::<FuzzyMatch>::new(),
+            token
+                .match_input("\"no\"", &app_meta())
+                .collect::<Vec<_>>()
+                .await,
+        );
+    }
+
+    fn app_meta() -> AppMeta {
+        AppMeta::new(NullDataStore, &event_dispatcher)
+    }
+
+    fn event_dispatcher(_event: Event) {}
+}

--- a/core/src/command/token/mod.rs
+++ b/core/src/command/token/mod.rs
@@ -1,0 +1,116 @@
+mod keyword;
+
+use crate::app::AppMeta;
+use crate::utils::Word;
+
+use std::pin::Pin;
+
+use futures::prelude::*;
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Token {
+    pub token_type: TokenType,
+    pub marker: Option<u8>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TokenMatch<'a> {
+    pub token: &'a Token,
+    pub match_meta: MatchMeta,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FuzzyMatch<'a> {
+    Overflow(TokenMatch<'a>, Word<'a>),
+    Exact(TokenMatch<'a>),
+    Partial(TokenMatch<'a>, Option<String>),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum TokenType {
+    /// A literal word
+    Keyword(&'static str),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MatchMeta {
+    None,
+}
+
+impl Token {
+    pub fn keyword(keyword: &'static str) -> Self {
+        Token {
+            token_type: TokenType::Keyword(keyword),
+            marker: None,
+        }
+    }
+
+    pub fn match_input<'a, 'b>(
+        &'a self,
+        input: &'a str,
+        _app_meta: &'b AppMeta,
+    ) -> Pin<Box<dyn Stream<Item = FuzzyMatch<'a>> + 'b>>
+    where
+        'a: 'b,
+    {
+        match &self.token_type {
+            TokenType::Keyword(..) => keyword::match_input(self, input),
+        }
+    }
+}
+
+impl<'a> TokenMatch<'a> {
+    pub fn new(token: &'a Token, match_meta: impl Into<MatchMeta>) -> Self {
+        TokenMatch {
+            token,
+            match_meta: match_meta.into(),
+        }
+    }
+}
+
+impl<'a> From<&'a Token> for TokenMatch<'a> {
+    fn from(input: &'a Token) -> Self {
+        TokenMatch::new(input, MatchMeta::None)
+    }
+}
+
+impl<'a> FuzzyMatch<'a> {
+    pub fn into_exact(self) -> Option<TokenMatch<'a>> {
+        if let FuzzyMatch::Exact(token_match) = self {
+            Some(token_match)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+
+    pub async fn assert_stream_eq<'a, T>(
+        mut expect_results: Vec<T>,
+        stream: Pin<Box<dyn Stream<Item = T> + 'a>>,
+    ) where
+        T: std::fmt::Debug + PartialEq,
+    {
+        for result in stream.collect::<Vec<_>>().await {
+            let Some(index) = expect_results
+                .iter()
+                .position(|expect_result| expect_result == &result)
+            else {
+                panic!(
+                    "Not found in expected results: {:?}\n\nRemaining expected results: {:?}",
+                    result, expect_results
+                );
+            };
+            expect_results.swap_remove(index);
+        }
+
+        assert_eq!(
+            Vec::<T>::new(),
+            expect_results,
+            "Expected all results to be exhausted",
+        );
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,6 +14,7 @@ pub use storage::{DataStore, MemoryDataStore, NullDataStore};
 pub use uuid::Uuid;
 pub use world::thing::Thing;
 
+mod command;
 mod reference;
 mod storage;
 mod time;

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -34,6 +34,7 @@ pub fn pluralize(word: &str) -> (&str, &str) {
     }
 }
 
+#[derive(Clone, Debug, Eq)]
 pub struct Word<'a> {
     phrase: &'a str,
     inner_range: Range<usize>,
@@ -42,6 +43,10 @@ pub struct Word<'a> {
 
 impl<'a> Word<'a> {
     fn new(phrase: &'a str, inner_range: Range<usize>, outer_range: Range<usize>) -> Self {
+        assert!(inner_range.start >= outer_range.start);
+        assert!(inner_range.end <= outer_range.end);
+        assert!(outer_range.end <= phrase.len());
+
         Self {
             phrase,
             inner_range,
@@ -55,5 +60,138 @@ impl<'a> Word<'a> {
 
     pub fn range(&self) -> Range<usize> {
         self.outer_range.clone()
+    }
+
+    /// Does this word appear at the end of the phrase (including any ignored characters)?
+    pub fn is_at_end(&self) -> bool {
+        self.outer_range.end == self.phrase.len()
+    }
+
+    /// Is the word quoted? (Are there characters consumed but ignored by this word?)
+    pub fn is_quoted(&self) -> bool {
+        self.inner_range != self.outer_range
+    }
+
+    /// Can the word be autocompleted? (Is it in such a position that adding characters to the end
+    /// of the overall phrase will extend the current word?)
+    pub fn can_complete(&self) -> bool {
+        self.is_at_end() && !self.is_quoted()
+    }
+
+    pub fn after(&self) -> Word<'a> {
+        Word {
+            phrase: self.phrase,
+            inner_range: self.outer_range.end..self.phrase.len(),
+            outer_range: self.outer_range.end..self.phrase.len(),
+        }
+    }
+}
+
+impl<'a> PartialEq for Word<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl<'a> AsRef<str> for Word<'a> {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<'a> From<&'a str> for Word<'a> {
+    fn from(input: &'a str) -> Word<'a> {
+        Word {
+            phrase: input,
+            inner_range: 0..input.len(),
+            outer_range: 0..input.len(),
+        }
+    }
+}
+
+impl<'a> From<&'a String> for Word<'a> {
+    fn from(input: &'a String) -> Word<'a> {
+        Word {
+            phrase: input,
+            inner_range: 0..input.len(),
+            outer_range: 0..input.len(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn new_test() {
+        assert_eq!(
+            Word {
+                phrase: "abc",
+                inner_range: 1..2,
+                outer_range: 0..3,
+            },
+            Word::new("abc", 1..2, 0..3),
+        );
+
+        Word::new("", 0..0, 0..0);
+        Word::new("a", 0..1, 0..1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn new_test_inner_starts_before_outer() {
+        Word::new("abc", 0..2, 1..3);
+    }
+
+    #[test]
+    #[should_panic]
+    fn new_test_inner_ends_after_outer() {
+        Word::new("abc", 1..3, 0..2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn new_test_range_too_long() {
+        Word::new("abc", 0..2, 0..4);
+    }
+
+    #[test]
+    fn as_str_test() {
+        let substr = {
+            let word = Word::new("abc", 1..2, 0..3);
+            word.as_str()
+        };
+
+        assert_eq!("b", substr);
+    }
+
+    #[test]
+    fn range_test() {
+        assert_eq!(0..3, Word::new("abc", 1..2, 0..3).range());
+    }
+
+    #[test]
+    fn is_at_end_test() {
+        assert!(Word::new("abc", 1..2, 1..3).is_at_end());
+        assert!(!Word::new("abc", 1..2, 1..2).is_at_end());
+    }
+
+    #[test]
+    fn is_quoted_test() {
+        assert!(Word::new("abc", 1..3, 0..3).is_quoted());
+        assert!(!Word::new("abc", 1..3, 1..3).is_quoted());
+    }
+
+    #[test]
+    fn can_complete_test() {
+        assert!(Word::new("abc", 1..3, 1..3).can_complete());
+        assert!(!Word::new("abc", 1..2, 1..2).can_complete());
+        assert!(!Word::new("abc", 1..2, 1..3).can_complete());
+    }
+
+    #[test]
+    fn after_test() {
+        assert_eq!("c", Word::new("abc", 0..1, 0..2).after().as_str());
     }
 }

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -49,15 +49,11 @@ impl<'a> Word<'a> {
         }
     }
 
-    pub fn as_str(&'a self) -> &'a str {
+    pub fn as_str(&self) -> &'a str {
         &self.phrase[self.inner_range.clone()]
     }
 
-    pub fn as_own_str<'b>(&'a self, phrase: &'b str) -> &'b str {
-        &phrase[self.inner_range.clone()]
-    }
-
-    pub fn range(&'a self) -> &'a Range<usize> {
-        &self.outer_range
+    pub fn range(&self) -> Range<usize> {
+        self.outer_range.clone()
     }
 }

--- a/core/src/utils/quoted_word_iter.rs
+++ b/core/src/utils/quoted_word_iter.rs
@@ -126,19 +126,19 @@ mod test {
 
         let word = input_iter.next().unwrap();
         assert_eq!("a", word.as_str());
-        assert_eq!(0..1, *word.range());
+        assert_eq!(0..1, word.range());
 
         let word = input_iter.next().unwrap();
         assert_eq!("boy", word.as_str());
-        assert_eq!(2..5, *word.range());
+        assert_eq!(2..5, word.range());
 
         let word = input_iter.next().unwrap();
         assert_eq!("named", word.as_str());
-        assert_eq!(8..13, *word.range());
+        assert_eq!(8..13, word.range());
 
         let word = input_iter.next().unwrap();
         assert_eq!("Johnny Cash", word.as_str());
-        assert_eq!(14..27, *word.range());
+        assert_eq!(14..27, word.range());
 
         assert!(input_iter.next().is_none());
     }
@@ -150,19 +150,19 @@ mod test {
 
         let word = input_iter.next().unwrap();
         assert_eq!("Legolas", word.as_str());
-        assert_eq!(0..9, *word.range());
+        assert_eq!(0..9, word.range());
 
         let word = input_iter.next().unwrap();
         assert_eq!(",", word.as_str());
-        assert_eq!(9..10, *word.range());
+        assert_eq!(9..10, word.range());
 
         let word = input_iter.next().unwrap();
         assert_eq!("an", word.as_str());
-        assert_eq!(11..13, *word.range());
+        assert_eq!(11..13, word.range());
 
         let word = input_iter.next().unwrap();
         assert_eq!("elf", word.as_str());
-        assert_eq!(14..17, *word.range());
+        assert_eq!(14..17, word.range());
 
         assert!(input_iter.next().is_none());
     }
@@ -174,7 +174,7 @@ mod test {
 
         let word = input_iter.next().unwrap();
         assert_eq!("", word.as_str());
-        assert_eq!(0..2, *word.range());
+        assert_eq!(0..2, word.range());
 
         assert!(input_iter.next().is_none());
     }
@@ -186,15 +186,15 @@ mod test {
 
         let word = input_iter.next().unwrap();
         assert_eq!("bl", word.as_str());
-        assert_eq!(2..4, *word.range());
+        assert_eq!(2..4, word.range());
 
         let word = input_iter.next().unwrap();
         assert_eq!("", word.as_str());
-        assert_eq!(4..6, *word.range());
+        assert_eq!(4..6, word.range());
 
         let word = input_iter.next().unwrap();
         assert_eq!("ah", word.as_str());
-        assert_eq!(6..8, *word.range());
+        assert_eq!(6..8, word.range());
 
         assert!(input_iter.next().is_none());
     }
@@ -206,11 +206,11 @@ mod test {
 
         let word = input_iter.next().unwrap();
         assert_eq!("bl", word.as_str());
-        assert_eq!(2..4, *word.range());
+        assert_eq!(2..4, word.range());
 
         let word = input_iter.next().unwrap();
         assert_eq!("ah ", word.as_str());
-        assert_eq!(4..8, *word.range());
+        assert_eq!(4..8, word.range());
 
         assert!(input_iter.next().is_none());
     }
@@ -222,7 +222,7 @@ mod test {
 
         let word = input_iter.next().unwrap();
         assert_eq!("", word.as_str());
-        assert_eq!(1..2, *word.range());
+        assert_eq!(1..2, word.range());
 
         assert!(input_iter.next().is_none());
     }
@@ -234,11 +234,11 @@ mod test {
 
         let word = input_iter.next().unwrap();
         assert_eq!("bl", word.as_str());
-        assert_eq!(2..4, *word.range());
+        assert_eq!(2..4, word.range());
 
         let word = input_iter.next().unwrap();
         assert_eq!("", word.as_str());
-        assert_eq!(4..5, *word.range());
+        assert_eq!(4..5, word.range());
 
         assert!(input_iter.next().is_none());
     }
@@ -250,7 +250,7 @@ mod test {
 
         let word = input_iter.next().unwrap();
         assert_eq!("🥔", word.as_str());
-        assert_eq!(0..4, *word.range());
+        assert_eq!(0..4, word.range());
 
         assert!(input_iter.next().is_none());
     }

--- a/core/src/world/command/autocomplete.rs
+++ b/core/src/world/command/autocomplete.rs
@@ -147,7 +147,7 @@ fn autocomplete_terms<T: Default + FromStr + Into<ThingData>>(
             let mut suggestions = Vec::new();
 
             let words: HashSet<&str> = quoted_words(parsed.desc_lower())
-                .map(|word| word.as_own_str(parsed.desc_lower()))
+                .map(|word| word.as_str())
                 .collect();
 
             if thing_data.name().is_none() {
@@ -174,7 +174,7 @@ fn autocomplete_terms<T: Default + FromStr + Into<ThingData>>(
         // Multiple words: make suggestions if existing words made sense.
         let words: HashSet<&str> = {
             quoted_words(parsed.desc_lower())
-                .map(|word| word.as_own_str(parsed.desc_lower()))
+                .map(|word| word.as_str())
                 .filter(|s| s != &parsed.partial && !s.in_ci(ARTICLES))
                 .collect()
         };

--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,3 +1,5 @@
+* **Enhancement:** Migrate the `about` command to use a new architecture. (No
+  user-facing impact but it was a lot of work.) @MikkelPaulson
 * **Enhancement:** Feature parity for CLI autocompletion. @mplauman
 * **Enhancement:** Name generator now works for `theater`. @azylko
 * **Bug:** Fixed a positioning issue with the autocomplete popup. @MikkelPaulson

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -13,6 +13,7 @@ proc-macro = true
 
 [dependencies]
 initiative-reference = { path = "../reference" }
+proc-macro2 = "1.0.86"
 quote = "1.0"
 regex = "1.7"
 syn = "1.0"

--- a/macros/src/command_list.rs
+++ b/macros/src/command_list.rs
@@ -1,0 +1,226 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub fn run(input: TokenStream) -> Result<TokenStream, String> {
+    let ast = syn::parse2(input).map_err(|e| e.to_string())?;
+    impl_command_list(&ast)
+}
+
+fn impl_command_list(ast: &syn::DeriveInput) -> Result<TokenStream, String> {
+    let syn::Data::Enum(syn::DataEnum { variants, .. }) = &ast.data else {
+        return Err("CommandList can only be derived on enums.".to_string());
+    };
+
+    let ident = &ast.ident;
+
+    if let Some(variant) = variants.iter().find(|variant| {
+        if let syn::Fields::Unnamed(field) = &variant.fields {
+            field.unnamed.len() != 1
+        } else {
+            true
+        }
+    }) {
+        return Err(format!(
+            "{}::{}: CommandList enums must have only tuple variants with a single field",
+            ident, variant.ident
+        ));
+    }
+
+    let (get_all_items, match_items): (Vec<_>, Vec<_>) = variants
+        .iter()
+        .map(|variant| {
+            let variant_ident = &variant.ident;
+            let syn::Fields::Unnamed(syn::FieldsUnnamed { unnamed: field, .. }) = &variant.fields
+            else {
+                unreachable!();
+            };
+
+            (
+                quote! { #ident::#variant_ident(#field), },
+                quote! { #ident::#variant_ident(c) },
+            )
+        })
+        .unzip();
+
+    Ok(quote! {
+        impl #ident {
+            const fn get_all() -> &'static [#ident] {
+                &[
+                    #( #get_all_items )*
+                ]
+            }
+        }
+
+        impl Command for #ident {
+            fn token(&self) -> Token {
+                match self {
+                    #( #match_items => c.token(), )*
+                }
+            }
+
+            fn autocomplete(&self, fuzzy_match: FuzzyMatch, input: &str) -> Option<AutocompleteSuggestion> {
+                match self {
+                    #( #match_items => c.autocomplete(fuzzy_match, input), )*
+                }
+            }
+
+            fn get_priority(&self, token_match: &TokenMatch) -> Option<CommandPriority> {
+                match self {
+                    #( #match_items => c.get_priority(token_match), )*
+                }
+            }
+
+            fn get_canonical_form_of(&self, token_match: &TokenMatch) -> Option<String> {
+                match self {
+                    #( #match_items => c.get_canonical_form_of(token_match), )*
+                }
+            }
+
+            async fn run<'a>(
+                &self,
+                token_match: TokenMatch<'a>,
+                app_meta: &mut AppMeta,
+            ) -> Result<String, String> {
+                match self {
+                    #( #match_items => c.run(token_match, app_meta).await, )*
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn success_test() {
+        assert_eq!(
+            quote! {
+                impl CommandList {
+                    const fn get_all() -> &'static [CommandList] {
+                        &[
+                            CommandList::About(about::About),
+                            CommandList::Create(create::Create),
+                            CommandList::Save(save::Save),
+                        ]
+                    }
+                }
+
+                impl Command for CommandList {
+                    fn token(&self) -> Token {
+                        match self {
+                            CommandList::About(c) => c.token(),
+                            CommandList::Create(c) => c.token(),
+                            CommandList::Save(c) => c.token(),
+                        }
+                    }
+
+                    fn autocomplete(&self, fuzzy_match: FuzzyMatch, input: &str) -> Option<AutocompleteSuggestion> {
+                        match self {
+                            CommandList::About(c) => c.autocomplete(fuzzy_match, input),
+                            CommandList::Create(c) => c.autocomplete(fuzzy_match, input),
+                            CommandList::Save(c) => c.autocomplete(fuzzy_match, input),
+                        }
+                    }
+
+                    fn get_priority(&self, token_match: &TokenMatch) -> Option<CommandPriority> {
+                        match self {
+                            CommandList::About(c) => c.get_priority(token_match),
+                            CommandList::Create(c) => c.get_priority(token_match),
+                            CommandList::Save(c) => c.get_priority(token_match),
+                        }
+                    }
+
+                    fn get_canonical_form_of(&self, token_match: &TokenMatch) -> Option<String> {
+                        match self {
+                            CommandList::About(c) => c.get_canonical_form_of(token_match),
+                            CommandList::Create(c) => c.get_canonical_form_of(token_match),
+                            CommandList::Save(c) => c.get_canonical_form_of(token_match),
+                        }
+                    }
+
+                    async fn run<'a>(
+                        &self,
+                        token_match: TokenMatch<'a>,
+                        app_meta: &mut AppMeta,
+                    ) -> Result<String, String> {
+                        match self {
+                            CommandList::About(c) => c.run(token_match, app_meta).await,
+                            CommandList::Create(c) => c.run(token_match, app_meta).await,
+                            CommandList::Save(c) => c.run(token_match, app_meta).await,
+                        }
+                    }
+                }
+            }
+            .to_string(),
+            run(quote! {
+                enum CommandList {
+                    About(about::About),
+                    Create(create::Create),
+                    Save(save::Save),
+                }
+            })
+            .unwrap()
+            .to_string()
+        );
+    }
+
+    #[test]
+    fn failure_test_not_enum() {
+        assert_eq!(
+            "CommandList can only be derived on enums.",
+            run(quote! {
+                struct MarkerSchmarker;
+            })
+            .unwrap_err(),
+        );
+    }
+
+    #[test]
+    fn failure_test_unit_variant() {
+        assert_eq!(
+            "CommandList::Bad: CommandList enums must have only tuple variants with a single field",
+            run(quote! {
+                enum CommandList {
+                    Good(good::Good),
+                    Bad,
+                    GoodAgain(good_again::GoodAgain),
+                }
+            })
+            .unwrap_err(),
+        );
+    }
+
+    #[test]
+    fn failure_test_struct_variant() {
+        assert_eq!(
+            "CommandList::Bad: CommandList enums must have only tuple variants with a single field",
+            run(quote! {
+                enum CommandList {
+                    Good(good::Good),
+                    Bad {
+                        worse: worse::Worse,
+                    },
+                    GoodAgain(good_again::GoodAgain),
+                }
+            })
+            .unwrap_err(),
+        );
+    }
+
+    #[test]
+    fn failure_test_tuple_variant_too_big() {
+        assert_eq!(
+            "CommandList::Bad: CommandList enums must have only tuple variants with a single field",
+            run(quote! {
+                enum CommandList {
+                    Good(good::Good),
+                    Bad(okay::Okay, bad::Bad),
+                    GoodAgain(good_again::GoodAgain),
+                }
+            })
+            .unwrap_err(),
+        );
+    }
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -9,6 +9,7 @@ use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
 mod changelog;
+mod command_list;
 mod motd;
 mod reference_enum;
 mod token_marker;
@@ -19,6 +20,12 @@ mod word_list;
 #[proc_macro]
 pub fn changelog(input: TokenStream) -> TokenStream {
     changelog::run(input).unwrap()
+}
+
+#[proc_macro_derive(CommandList)]
+pub fn command_list(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input);
+    command_list::run(input).unwrap().into()
 }
 
 /// A microoptimization that generates the welcome message as a static string combined from several

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -6,10 +6,12 @@
 //! organization here; they're just all dependencies in one way or another.
 
 use proc_macro::TokenStream;
+use syn::parse_macro_input;
 
 mod changelog;
 mod motd;
 mod reference_enum;
+mod token_marker;
 mod word_list;
 
 /// A microoptimization to compile only part of the lengthy `changelog.md` file into the
@@ -32,6 +34,12 @@ pub fn motd(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn reference_enum(input: TokenStream) -> TokenStream {
     reference_enum::run(input).unwrap()
+}
+
+#[proc_macro_derive(TokenMarker)]
+pub fn token_marker(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input);
+    token_marker::run(input).unwrap().into()
 }
 
 /// There are a lot of enums containing lists of terms scattered throughout the application. In

--- a/macros/src/token_marker.rs
+++ b/macros/src/token_marker.rs
@@ -1,0 +1,285 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub fn run(input: TokenStream) -> Result<TokenStream, String> {
+    let ast = syn::parse2(input).map_err(|e| e.to_string())?;
+    impl_token_marker(&ast)
+}
+
+fn impl_token_marker(ast: &syn::DeriveInput) -> Result<TokenStream, String> {
+    let syn::Data::Enum(syn::DataEnum { variants, .. }) = &ast.data else {
+        return Err("TokenMarker can only be derived on enums.".to_string());
+    };
+
+    let ident = &ast.ident;
+
+    if let Some(variant) = variants
+        .iter()
+        .find(|variant| !matches!(variant.fields, syn::Fields::Unit))
+    {
+        return Err(format!(
+            "{}::{}: TokenMarker enums must have only unit variants",
+            ident, variant.ident
+        ));
+    }
+
+    if variants.len() > 256 {
+        return Err(
+            "A maximum of 256 marker variants are permitted. What kind of enum is this?!"
+                .to_string(),
+        );
+    }
+
+    let (from_u8, into_u8): (Vec<_>, Vec<_>) = variants
+        .iter()
+        .enumerate()
+        .map(|(i, variant)| {
+            let i = i as u8;
+            let variant_ident = &variant.ident;
+            (
+                quote! { #i => #ident::#variant_ident, },
+                quote! { #ident::#variant_ident => #i, },
+            )
+        })
+        .unzip();
+
+    Ok(quote! {
+        impl TryFrom<u8> for #ident {
+            type Error = ();
+
+            fn try_from(input: u8) -> Result<#ident, ()> {
+                Ok(match input {
+                    #(#from_u8)*
+                    _ => return Err(()),
+                })
+            }
+        }
+
+        impl From<#ident> for u8 {
+            fn from(input: #ident) -> u8 {
+                (&input).into()
+            }
+        }
+
+        impl From<&#ident> for u8 {
+            fn from(input: &#ident) -> u8 {
+                match input {
+                    #(#into_u8)*
+                }
+            }
+        }
+
+        impl PartialEq<u8> for #ident {
+            fn eq(&self, other: &u8) -> bool {
+                &u8::from(self) == other
+            }
+        }
+
+        impl PartialEq<u8> for &#ident {
+            fn eq(&self, other: &u8) -> bool {
+                &u8::from(*self) == other
+            }
+        }
+
+        impl PartialEq<#ident> for u8 {
+            fn eq(&self, other: &#ident) -> bool {
+                self == &u8::from(other)
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn success_test() {
+        assert_eq!(
+            quote! {
+                impl TryFrom<u8> for MarkerSchmarker {
+                    type Error = ();
+
+                    fn try_from(input: u8) -> Result<MarkerSchmarker, ()> {
+                        Ok(match input {
+                            0u8 => MarkerSchmarker::One,
+                            1u8 => MarkerSchmarker::Two,
+                            2u8 => MarkerSchmarker::Three,
+                            _ => return Err(()),
+                        })
+                    }
+                }
+
+                impl From<MarkerSchmarker> for u8 {
+                    fn from(input: MarkerSchmarker) -> u8 {
+                        (&input).into()
+                    }
+                }
+
+                impl From<&MarkerSchmarker> for u8 {
+                    fn from(input: &MarkerSchmarker) -> u8 {
+                        match input {
+                            MarkerSchmarker::One => 0u8,
+                            MarkerSchmarker::Two => 1u8,
+                            MarkerSchmarker::Three => 2u8,
+                        }
+                    }
+                }
+
+                impl PartialEq<u8> for MarkerSchmarker {
+                    fn eq(&self, other: &u8) -> bool {
+                        &u8::from(self) == other
+                    }
+                }
+
+                impl PartialEq<u8> for &MarkerSchmarker {
+                    fn eq(&self, other: &u8) -> bool {
+                        &u8::from(*self) == other
+                    }
+                }
+
+                impl PartialEq<MarkerSchmarker> for u8 {
+                    fn eq(&self, other: &MarkerSchmarker) -> bool {
+                        self == &u8::from(other)
+                    }
+                }
+            }
+            .to_string(),
+            run(quote! {
+                enum MarkerSchmarker {
+                    One,
+                    Two = 3,
+                    Three,
+                }
+            })
+            .unwrap()
+            .to_string()
+        );
+    }
+
+    #[test]
+    fn failure_test_not_enum() {
+        assert_eq!(
+            "TokenMarker can only be derived on enums.",
+            run(quote! {
+                struct MarkerSchmarker;
+            })
+            .unwrap_err(),
+        );
+    }
+
+    #[test]
+    fn failure_test_tuple_variant() {
+        assert_eq!(
+            "MarkerSchmarker::Bad: TokenMarker enums must have only unit variants",
+            run(quote! {
+                enum MarkerSchmarker {
+                    Good,
+                    Bad(Worse),
+                    GoodAgain,
+                }
+            })
+            .unwrap_err(),
+        );
+    }
+
+    #[test]
+    fn failure_test_struct_variant() {
+        assert_eq!(
+            "MarkerSchmarker::Bad: TokenMarker enums must have only unit variants",
+            run(quote! {
+                enum MarkerSchmarker {
+                    Good,
+                    Bad {
+                        worse: Worse,
+                    },
+                    GoodAgain,
+                }
+            })
+            .unwrap_err(),
+        );
+    }
+
+    #[test]
+    fn failure_test_took_big() {
+        assert!(run(quote! {
+            enum MarkerSchmarker {
+                Good0x00, Good0x01, Good0x02, Good0x03, Good0x04, Good0x05, Good0x06, Good0x07,
+                Good0x08, Good0x09, Good0x0a, Good0x0b, Good0x0c, Good0x0d, Good0x0e, Good0x0f,
+                Good0x10, Good0x11, Good0x12, Good0x13, Good0x14, Good0x15, Good0x16, Good0x17,
+                Good0x18, Good0x19, Good0x1a, Good0x1b, Good0x1c, Good0x1d, Good0x1e, Good0x2f,
+                Good0x20, Good0x21, Good0x22, Good0x23, Good0x24, Good0x25, Good0x26, Good0x27,
+                Good0x28, Good0x29, Good0x2a, Good0x2b, Good0x2c, Good0x2d, Good0x2e, Good0x3f,
+                Good0x30, Good0x31, Good0x32, Good0x33, Good0x34, Good0x35, Good0x36, Good0x37,
+                Good0x38, Good0x39, Good0x3a, Good0x3b, Good0x3c, Good0x3d, Good0x3e, Good0x4f,
+                Good0x40, Good0x41, Good0x42, Good0x43, Good0x44, Good0x45, Good0x46, Good0x47,
+                Good0x48, Good0x49, Good0x4a, Good0x4b, Good0x4c, Good0x4d, Good0x4e, Good0x5f,
+                Good0x50, Good0x51, Good0x52, Good0x53, Good0x54, Good0x55, Good0x56, Good0x57,
+                Good0x58, Good0x59, Good0x5a, Good0x5b, Good0x5c, Good0x5d, Good0x5e, Good0x6f,
+                Good0x60, Good0x61, Good0x62, Good0x63, Good0x64, Good0x65, Good0x66, Good0x67,
+                Good0x68, Good0x69, Good0x6a, Good0x6b, Good0x6c, Good0x6d, Good0x6e, Good0x7f,
+                Good0x70, Good0x71, Good0x72, Good0x73, Good0x74, Good0x75, Good0x76, Good0x77,
+                Good0x78, Good0x79, Good0x7a, Good0x7b, Good0x7c, Good0x7d, Good0x7e, Good0x8f,
+                Good0x80, Good0x81, Good0x82, Good0x83, Good0x84, Good0x85, Good0x86, Good0x87,
+                Good0x88, Good0x89, Good0x8a, Good0x8b, Good0x8c, Good0x8d, Good0x8e, Good0x9f,
+                Good0x90, Good0x91, Good0x92, Good0x93, Good0x94, Good0x95, Good0x96, Good0x97,
+                Good0x98, Good0x99, Good0x9a, Good0x9b, Good0x9c, Good0x9d, Good0x9e, Good0xaf,
+                Good0xa0, Good0xa1, Good0xa2, Good0xa3, Good0xa4, Good0xa5, Good0xa6, Good0xa7,
+                Good0xa8, Good0xa9, Good0xaa, Good0xab, Good0xac, Good0xad, Good0xae, Good0xbf,
+                Good0xb0, Good0xb1, Good0xb2, Good0xb3, Good0xb4, Good0xb5, Good0xb6, Good0xb7,
+                Good0xb8, Good0xb9, Good0xba, Good0xbb, Good0xbc, Good0xbd, Good0xbe, Good0xcf,
+                Good0xc0, Good0xc1, Good0xc2, Good0xc3, Good0xc4, Good0xc5, Good0xc6, Good0xc7,
+                Good0xc8, Good0xc9, Good0xca, Good0xcb, Good0xcc, Good0xcd, Good0xce, Good0xdf,
+                Good0xd0, Good0xd1, Good0xd2, Good0xd3, Good0xd4, Good0xd5, Good0xd6, Good0xd7,
+                Good0xd8, Good0xd9, Good0xda, Good0xdb, Good0xdc, Good0xdd, Good0xde, Good0xef,
+                Good0xe0, Good0xe1, Good0xe2, Good0xe3, Good0xe4, Good0xe5, Good0xe6, Good0xe7,
+                Good0xe8, Good0xe9, Good0xea, Good0xeb, Good0xec, Good0xed, Good0xee, Good0xff,
+                Good0xf0, Good0xf1, Good0xf2, Good0xf3, Good0xf4, Good0xf5, Good0xf6, Good0xf7,
+                Good0xf8, Good0xf9, Good0xfa, Good0xfb, Good0xfc, Good0xfd, Good0xfe, Good0xff,
+            }
+        })
+        .is_ok());
+
+        assert_eq!(
+            "A maximum of 256 marker variants are permitted. What kind of enum is this?!",
+            run(quote! {
+                enum MarkerSchmarker {
+                    Good0x00, Good0x01, Good0x02, Good0x03, Good0x04, Good0x05, Good0x06, Good0x07,
+                    Good0x08, Good0x09, Good0x0a, Good0x0b, Good0x0c, Good0x0d, Good0x0e, Good0x0f,
+                    Good0x10, Good0x11, Good0x12, Good0x13, Good0x14, Good0x15, Good0x16, Good0x17,
+                    Good0x18, Good0x19, Good0x1a, Good0x1b, Good0x1c, Good0x1d, Good0x1e, Good0x2f,
+                    Good0x20, Good0x21, Good0x22, Good0x23, Good0x24, Good0x25, Good0x26, Good0x27,
+                    Good0x28, Good0x29, Good0x2a, Good0x2b, Good0x2c, Good0x2d, Good0x2e, Good0x3f,
+                    Good0x30, Good0x31, Good0x32, Good0x33, Good0x34, Good0x35, Good0x36, Good0x37,
+                    Good0x38, Good0x39, Good0x3a, Good0x3b, Good0x3c, Good0x3d, Good0x3e, Good0x4f,
+                    Good0x40, Good0x41, Good0x42, Good0x43, Good0x44, Good0x45, Good0x46, Good0x47,
+                    Good0x48, Good0x49, Good0x4a, Good0x4b, Good0x4c, Good0x4d, Good0x4e, Good0x5f,
+                    Good0x50, Good0x51, Good0x52, Good0x53, Good0x54, Good0x55, Good0x56, Good0x57,
+                    Good0x58, Good0x59, Good0x5a, Good0x5b, Good0x5c, Good0x5d, Good0x5e, Good0x6f,
+                    Good0x60, Good0x61, Good0x62, Good0x63, Good0x64, Good0x65, Good0x66, Good0x67,
+                    Good0x68, Good0x69, Good0x6a, Good0x6b, Good0x6c, Good0x6d, Good0x6e, Good0x7f,
+                    Good0x70, Good0x71, Good0x72, Good0x73, Good0x74, Good0x75, Good0x76, Good0x77,
+                    Good0x78, Good0x79, Good0x7a, Good0x7b, Good0x7c, Good0x7d, Good0x7e, Good0x8f,
+                    Good0x80, Good0x81, Good0x82, Good0x83, Good0x84, Good0x85, Good0x86, Good0x87,
+                    Good0x88, Good0x89, Good0x8a, Good0x8b, Good0x8c, Good0x8d, Good0x8e, Good0x9f,
+                    Good0x90, Good0x91, Good0x92, Good0x93, Good0x94, Good0x95, Good0x96, Good0x97,
+                    Good0x98, Good0x99, Good0x9a, Good0x9b, Good0x9c, Good0x9d, Good0x9e, Good0xaf,
+                    Good0xa0, Good0xa1, Good0xa2, Good0xa3, Good0xa4, Good0xa5, Good0xa6, Good0xa7,
+                    Good0xa8, Good0xa9, Good0xaa, Good0xab, Good0xac, Good0xad, Good0xae, Good0xbf,
+                    Good0xb0, Good0xb1, Good0xb2, Good0xb3, Good0xb4, Good0xb5, Good0xb6, Good0xb7,
+                    Good0xb8, Good0xb9, Good0xba, Good0xbb, Good0xbc, Good0xbd, Good0xbe, Good0xcf,
+                    Good0xc0, Good0xc1, Good0xc2, Good0xc3, Good0xc4, Good0xc5, Good0xc6, Good0xc7,
+                    Good0xc8, Good0xc9, Good0xca, Good0xcb, Good0xcc, Good0xcd, Good0xce, Good0xdf,
+                    Good0xd0, Good0xd1, Good0xd2, Good0xd3, Good0xd4, Good0xd5, Good0xd6, Good0xd7,
+                    Good0xd8, Good0xd9, Good0xda, Good0xdb, Good0xdc, Good0xdd, Good0xde, Good0xef,
+                    Good0xe0, Good0xe1, Good0xe2, Good0xe3, Good0xe4, Good0xe5, Good0xe6, Good0xe7,
+                    Good0xe8, Good0xe9, Good0xea, Good0xeb, Good0xec, Good0xed, Good0xee, Good0xff,
+                    Good0xf0, Good0xf1, Good0xf2, Good0xf3, Good0xf4, Good0xf5, Good0xf6, Good0xf7,
+                    Good0xf8, Good0xf9, Good0xfa, Good0xfb, Good0xfc, Good0xfd, Good0xfe, Good0xff,
+                    Bad,
+                }
+            })
+            .unwrap_err(),
+        );
+    }
+}

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 cargo test --workspace
 
-cargo clippy --workspace -- --deny warnings
+cargo clippy --workspace --tests -- --deny warnings
 
 git ls-files '*.rs' | xargs rustfmt --check --edition 2021
 if git grep ',)' '*.rs'; then


### PR DESCRIPTION
This lays the groundwork for migrating all commands to use a new token-based architecture, working towards #104. Some attention is given to avoiding unused code, because YAGNI (until the next command is migrated).

In order to make the work easier to reason about and avoid premature optimization, the migration will continue one command at a time until all are completed. Until that time, commands continue to be routed through the old architecture, using `TransitionalCommand` to represent a command that is parseable by the new architecture. The final step will be to remove that scaffold and route directly to the new architecture.

Development continues on #359, but future pull requests will be split off from that branch rather merging it directly.