### PR TITLE
Temporarily disable tutorial

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,3 +27,4 @@ tokio-test = "0.4"
 
 [features]
 js = ["uuid/stdweb"]
+tutorial = []

--- a/core/src/world/mod.rs
+++ b/core/src/world/mod.rs
@@ -3,7 +3,9 @@ pub mod npc;
 pub mod place;
 pub mod thing;
 
-pub use command::{ParsedThing, WorldCommand};
+#[cfg(any(feature = "tutorial", test))]
+pub use command::ParsedThing;
+pub use command::WorldCommand;
 pub use demographics::Demographics;
 pub use field::Field;
 

--- a/core/tests/integration/app/help.rs
+++ b/core/tests/integration/app/help.rs
@@ -17,6 +17,7 @@ fn all_commands_are_valid() {
             .skip(1)
             .step_by(2)
             .filter(|s| !s.contains('['))
+            .filter(|&s| s != "tutorial")
         {
             // Basically, we just want to make sure all commands run successfully.
             app.command(command).expect(command);

--- a/core/tests/integration/app/mod.rs
+++ b/core/tests/integration/app/mod.rs
@@ -3,6 +3,7 @@ mod changelog;
 mod debug;
 mod help;
 mod roll;
+#[cfg(feature = "tutorial")]
 mod tutorial;
 
 use crate::common::{get_name, sync_app};


### PR DESCRIPTION
The tutorial interferes with a lot of migration work and will need to be substantially reimplemented using the new command architecture. Rather than do an intermediate refactor, it's easier to disable it for now and do the migration work in a feature branch.